### PR TITLE
Using "provided" rather than "compile" for annnotations libraries.

### DIFF
--- a/drawee/build.gradle
+++ b/drawee/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'robolectric'
 dependencies {
     compile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"
     compile "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
     compile project(':fbcore')
 

--- a/fbcore/build.gradle
+++ b/fbcore/build.gradle
@@ -7,8 +7,8 @@ version = VERSION_NAME
 apply plugin: 'robolectric'
 
 dependencies {
-    compile "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
     androidTestCompile "com.google.guava:guava:${GUAVA_VERSION}"
     androidTestCompile "junit:junit:${JUNIT_VERSION}"

--- a/imagepipeline/build.gradle
+++ b/imagepipeline/build.gradle
@@ -10,11 +10,11 @@ import de.undercouch.gradle.tasks.download.Download
 import com.palominolabs.gradle.task.git.clone.GitCloneTask
 
 dependencies {
-    compile "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     compile "com.parse.bolts:bolts-android:${BOLTS_ANDROID_VERSION}"
     compile "com.nineoldandroids:library:${NINEOLDANDROID_VERSION}"
     compile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"
-    compile "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
     compile project(':fbcore')
     
     androidTestCompile "com.google.guava:guava:${GUAVA_VERSION}"


### PR DESCRIPTION
Although these are necessary for the compilation of the product, they are not needed at runtime and need not be/should not be shipped with the library. The change is semantically more correct, produces a better result, and decreases the chances of causing a dex issue with multiply defined symbols.