### PR TITLE
Fix small grammatical mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fresco also supports:
 * streaming of progressive JPEGs
 * display of animated GIFs and WebPs
 * extensive customization of image loading and display
-* and many more!
+* and much more!
 
 Find out more at our [website](http://frescolib.org/index.html).
 


### PR DESCRIPTION
This is a trivial change -- the list of features in the readme should end with "and much more," instead of, "and many more."