### PR TITLE
[Build] fix windows build

### DIFF
--- a/imagepipeline/build.gradle
+++ b/imagepipeline/build.gradle
@@ -6,6 +6,8 @@ version = VERSION_NAME
 
 apply plugin: 'robolectric'
 apply plugin: 'de.undercouch.download'
+
+import com.android.build.gradle.LibraryPlugin
 import de.undercouch.gradle.tasks.download.Download
 import com.palominolabs.gradle.task.git.clone.GitCloneTask
 
@@ -140,13 +142,22 @@ def getNdkBuildFullPath() {
     if (hasProperty('ndk.command')) {
         return property('ndk.command')
     }
-    // or just a path to the containing directiry
+    // or just a path to the containing directory
     if (hasProperty('ndk.path')) {
         def path = property('ndk.path')
         if (!path.endsWith(File.separator)) {
             path += File.separator
         }
         return path + getNdkBuildName()
+    }
+    // or full path to ndk-build tool based on android library plugin
+    def ndkFolder = ((LibraryPlugin) project.plugins
+            .findPlugin('com.android.library')).getNdkFolder().absolutePath
+    if (ndkFolder != null) {
+        if (!ndkFolder.endsWith(File.separator)) {
+            ndkFolder += File.separator
+        }
+        return ndkFolder + getNdkBuildName()
     }
     // if none of above is provided, we assume ndk-build is already in $PATH
     return getNdkBuildName()


### PR DESCRIPTION
ndk-build.cmd found in $PATH , but internal batch are apparently called with relative path. 

Using ndk-folder absolute path from gradle plugin seems to fix it.

:imagepipeline:copyGiflib
:imagepipeline:ndk_build_gifimage'"C:\Users\tbarthel\Documents\GitHub\fresco\imagepipeline\find-win-host.cmd"' not recognized as an internal or external command, operable program or batch file.'
 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':imagepipeline:ndk_build_gifimage'.
> Process 'command 'ndk-build.cmd'' finished with non-zero exit value 1

Could we only rely on the getNdkFolder or would it break "gradlew build" on other OS ?