### PR TITLE
Updating README to use version 0.2.0 to match docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Fresco supports Android 2.3 (Gingerbread) and later.
 If you are building with Gradle, simply add the following line to the `dependencies` section of your `build.gradle` file:
 
 ```groovy
-compile 'com.facebook.fresco:fresco:0.1.0+'
+compile 'com.facebook.fresco:fresco:0.2.0+'
 ```
 
 See our [download](http://frescolib.org/docs/download-fresco.html) page for other options.


### PR DESCRIPTION
The docs here recommend 0.2.0+
http://frescolib.org/docs/download-fresco.html

However the README recommends 0.1.0+