### PR TITLE
64-bit ARM and x86_64 - updating PR #121

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/gif/GifFrame.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/gif/GifFrame.java
@@ -25,7 +25,7 @@ public class GifFrame implements AnimatedImageFrame {
   // Accessed by native methods
   @SuppressWarnings("unused")
   @DoNotStrip
-  private int mNativeContext;
+  private long mNativeContext;
 
   /**
    * Constructs the frame with the native pointer. This is called by native code.
@@ -33,7 +33,7 @@ public class GifFrame implements AnimatedImageFrame {
    * @param nativeContext the native pointer
    */
   @DoNotStrip
-  GifFrame(int nativeContext) {
+  GifFrame(long nativeContext) {
     mNativeContext = nativeContext;
   }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/gif/GifImage.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/gif/GifImage.java
@@ -32,7 +32,7 @@ public class GifImage implements AnimatedImage {
   // Accessed by native methods
   @SuppressWarnings("unused")
   @DoNotStrip
-  private int mNativeContext;
+  private long mNativeContext;
 
   private static synchronized void ensure() {
     if (!sInitialized) {
@@ -72,7 +72,7 @@ public class GifImage implements AnimatedImage {
    * @param nativeContext the native pointer
    */
   @DoNotStrip
-  GifImage(int nativeContext) {
+  GifImage(long nativeContext) {
     mNativeContext = nativeContext;
   }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/webp/WebPFrame.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/webp/WebPFrame.java
@@ -25,7 +25,7 @@ public class WebPFrame implements AnimatedImageFrame {
   // Accessed by native methods
   @SuppressWarnings("unused")
   @DoNotStrip
-  private int mNativeContext;
+  private long mNativeContext;
 
   /**
    * Constructs the frame with the native pointer. This is called by native code.
@@ -33,7 +33,7 @@ public class WebPFrame implements AnimatedImageFrame {
    * @param nativeContext the native pointer
    */
   @DoNotStrip
-  WebPFrame(int nativeContext) {
+  WebPFrame(long nativeContext) {
     mNativeContext = nativeContext;
   }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/webp/WebPImage.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/webp/WebPImage.java
@@ -33,7 +33,7 @@ public class WebPImage implements AnimatedImage {
   // Accessed by native methods
   @SuppressWarnings("unused")
   @DoNotStrip
-  private int mNativeContext;
+  private long mNativeContext;
 
   private static synchronized void ensure() {
     if (!sInitialized) {
@@ -50,7 +50,7 @@ public class WebPImage implements AnimatedImage {
    * @param nativeContext the native pointer
    */
   @DoNotStrip
-  WebPImage(int nativeContext) {
+  WebPImage(long nativeContext) {
     mNativeContext = nativeContext;
   }
 

--- a/imagepipeline/src/main/jni/Application.mk
+++ b/imagepipeline/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 # Copyright 2004-present Facebook. All Rights Reserved.
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a armeabi x86
+APP_ABI := armeabi-v7a armeabi arm64-v8a x86 x86_64
 APP_PLATFORM := android-9
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))

--- a/imagepipeline/src/main/jni/gifimage/gif.cpp
+++ b/imagepipeline/src/main/jni/gifimage/gif.cpp
@@ -542,7 +542,7 @@ jobject GifImage_nativeCreateFromByteVector(JNIEnv* pEnv, std::vector<uint8_t>& 
   jobject ret = pEnv->NewObject(
       sClazzGifImage,
       sGifImageConstructor,
-      (long) spNativeContext.get());
+      (jlong) spNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spNativeContext->refCount = 1;
@@ -781,7 +781,7 @@ jobject GifImage_nativeGetFrame(JNIEnv* pEnv, jobject thiz, jint index) {
   jobject ret = pEnv->NewObject(
       sClazzGifFrame,
       sGifFrameConstructor,
-      (long) spFrameNativeContext.get());
+      (jlong) spFrameNativeContext.get());
   if (ret != nullptr) {
     // pEnv->NewObject will have already instructed the environment to throw an exception.
     spFrameNativeContext->refCount = 1;

--- a/imagepipeline/src/main/jni/gifimage/gif.cpp
+++ b/imagepipeline/src/main/jni/gifimage/gif.cpp
@@ -542,7 +542,7 @@ jobject GifImage_nativeCreateFromByteVector(JNIEnv* pEnv, std::vector<uint8_t>& 
   jobject ret = pEnv->NewObject(
       sClazzGifImage,
       sGifImageConstructor,
-      (jint) spNativeContext.get());
+      (long) spNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spNativeContext->refCount = 1;
@@ -591,7 +591,7 @@ std::unique_ptr<GifImageNativeContext, GifImageNativeContextReleaser>
   std::unique_ptr<GifImageNativeContext, GifImageNativeContextReleaser> ret(nullptr, releaser);
   pEnv->MonitorEnter(thiz);
   GifImageNativeContext* pNativeContext =
-      (GifImageNativeContext*) pEnv->GetIntField(thiz, sGifImageFieldNativeContext);
+      (GifImageNativeContext*) pEnv->GetLongField(thiz, sGifImageFieldNativeContext);
   if (pNativeContext != nullptr) {
     pNativeContext->refCount++;
     ret.reset(pNativeContext);
@@ -781,7 +781,7 @@ jobject GifImage_nativeGetFrame(JNIEnv* pEnv, jobject thiz, jint index) {
   jobject ret = pEnv->NewObject(
       sClazzGifFrame,
       sGifFrameConstructor,
-      (jint) spFrameNativeContext.get());
+      (long) spFrameNativeContext.get());
   if (ret != nullptr) {
     // pEnv->NewObject will have already instructed the environment to throw an exception.
     spFrameNativeContext->refCount = 1;
@@ -830,7 +830,7 @@ std::unique_ptr<GifFrameNativeContext, GifFrameNativeContextReleaser>
   std::unique_ptr<GifFrameNativeContext, GifFrameNativeContextReleaser> ret(nullptr, releaser);
   pEnv->MonitorEnter(thiz);
   GifFrameNativeContext* pNativeContext =
-      (GifFrameNativeContext*) pEnv->GetIntField(thiz, sGifFrameFieldNativeContext);
+      (GifFrameNativeContext*) pEnv->GetLongField(thiz, sGifFrameFieldNativeContext);
   if (pNativeContext != nullptr) {
     pNativeContext->refCount++;
     ret.reset(pNativeContext);
@@ -865,7 +865,7 @@ jint GifImage_nativeGetSizeInBytes(JNIEnv* pEnv, jobject thiz) {
 void GifImage_nativeDispose(JNIEnv* pEnv, jobject thiz) {
   pEnv->MonitorEnter(thiz);
   GifImageNativeContext* pNativeContext =
-      (GifImageNativeContext*) pEnv->GetIntField(thiz, sGifImageFieldNativeContext);
+      (GifImageNativeContext*) pEnv->GetLongField(thiz, sGifImageFieldNativeContext);
   if (pNativeContext != nullptr) {
     pEnv->SetIntField(thiz, sGifImageFieldNativeContext, 0);
     GifImageNativeContext_releaseRef(pEnv, thiz, pNativeContext);
@@ -1157,7 +1157,7 @@ jint GifFrame_nativeGetDisposalMode(JNIEnv* pEnv, jobject thiz) {
 void GifFrame_nativeDispose(JNIEnv* pEnv, jobject thiz) {
   pEnv->MonitorEnter(thiz);
   GifFrameNativeContext* pNativeContext =
-      (GifFrameNativeContext*) pEnv->GetIntField(thiz, sGifFrameFieldNativeContext);
+      (GifFrameNativeContext*) pEnv->GetLongField(thiz, sGifFrameFieldNativeContext);
   if (pNativeContext) {
     pEnv->SetIntField(thiz, sGifFrameFieldNativeContext, 0);
     GifFrameNativeContext_releaseRef(pEnv, thiz, pNativeContext);

--- a/imagepipeline/src/main/jni/webpimage/webp.cpp
+++ b/imagepipeline/src/main/jni/webpimage/webp.cpp
@@ -227,7 +227,7 @@ jobject WebPImage_nativeCreateFromByteVector(JNIEnv* pEnv, std::vector<uint8_t>&
   jobject ret = pEnv->NewObject(
       sClazzWebPImage,
       sWebPImageConstructor,
-      (jint) spNativeContext.get());
+      (long) spNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spNativeContext->refCount = 1;
@@ -279,7 +279,7 @@ std::unique_ptr<WebPImageNativeContext, WebPImageNativeContextReleaser>
   std::unique_ptr<WebPImageNativeContext, WebPImageNativeContextReleaser> ret(nullptr, releaser);
   pEnv->MonitorEnter(thiz);
   WebPImageNativeContext* pNativeContext =
-      (WebPImageNativeContext*) pEnv->GetIntField(thiz, sWebPImageFieldNativeContext);
+      (WebPImageNativeContext*) pEnv->GetLongField(thiz, sWebPImageFieldNativeContext);
   if (pNativeContext != nullptr) {
     pNativeContext->refCount++;
     ret.reset(pNativeContext);
@@ -475,7 +475,7 @@ jobject WebPImage_nativeGetFrame(JNIEnv* pEnv, jobject thiz, jint index) {
   jobject ret = pEnv->NewObject(
       sClazzWebPFrame,
       sWebPFrameConstructor,
-      (jint) spFrameNativeContext.get());
+      (long) spFrameNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spFrameNativeContext->refCount = 1;
@@ -526,7 +526,7 @@ std::unique_ptr<WebPFrameNativeContext, WebPFrameNativeContextReleaser>
   std::unique_ptr<WebPFrameNativeContext, WebPFrameNativeContextReleaser> ret(nullptr, releaser);
   pEnv->MonitorEnter(thiz);
   WebPFrameNativeContext* pNativeContext =
-      (WebPFrameNativeContext*) pEnv->GetIntField(thiz, sWebPFrameFieldNativeContext);
+      (WebPFrameNativeContext*) pEnv->GetLongField(thiz, sWebPFrameFieldNativeContext);
   if (pNativeContext != nullptr) {
     pNativeContext->refCount++;
     ret.reset(pNativeContext);
@@ -556,7 +556,7 @@ jint WebPImage_nativeGetSizeInBytes(JNIEnv* pEnv, jobject thiz) {
 void WebImage_nativeDispose(JNIEnv* pEnv, jobject thiz) {
   pEnv->MonitorEnter(thiz);
   WebPImageNativeContext* pNativeContext =
-      (WebPImageNativeContext*) pEnv->GetIntField(thiz, sWebPImageFieldNativeContext);
+      (WebPImageNativeContext*) pEnv->GetLongField(thiz, sWebPImageFieldNativeContext);
   if (pNativeContext != nullptr) {
     pEnv->SetIntField(thiz, sWebPImageFieldNativeContext, 0);
     WebPImageNativeContext_releaseRef(pEnv, thiz, pNativeContext);
@@ -761,7 +761,7 @@ jboolean WebPFrame_nativeShouldBlendWithPreviousFrame(JNIEnv* pEnv, jobject thiz
 void WebPFrame_nativeDispose(JNIEnv* pEnv, jobject thiz) {
   pEnv->MonitorEnter(thiz);
   WebPFrameNativeContext* pNativeContext =
-      (WebPFrameNativeContext*) pEnv->GetIntField(thiz, sWebPFrameFieldNativeContext);
+      (WebPFrameNativeContext*) pEnv->GetLongField(thiz, sWebPFrameFieldNativeContext);
   if (pNativeContext) {
     pEnv->SetIntField(thiz, sWebPFrameFieldNativeContext, 0);
     WebPFrameNativeContext_releaseRef(pEnv, thiz, pNativeContext);

--- a/imagepipeline/src/main/jni/webpimage/webp.cpp
+++ b/imagepipeline/src/main/jni/webpimage/webp.cpp
@@ -227,7 +227,7 @@ jobject WebPImage_nativeCreateFromByteVector(JNIEnv* pEnv, std::vector<uint8_t>&
   jobject ret = pEnv->NewObject(
       sClazzWebPImage,
       sWebPImageConstructor,
-      (long) spNativeContext.get());
+      (jlong) spNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spNativeContext->refCount = 1;
@@ -475,7 +475,7 @@ jobject WebPImage_nativeGetFrame(JNIEnv* pEnv, jobject thiz, jint index) {
   jobject ret = pEnv->NewObject(
       sClazzWebPFrame,
       sWebPFrameConstructor,
-      (long) spFrameNativeContext.get());
+      (jlong) spFrameNativeContext.get());
   if (ret != nullptr) {
     // Ownership was transferred.
     spFrameNativeContext->refCount = 1;


### PR DESCRIPTION
Just finishing updating PR #121 @orospakr started, by updating the files that @michalgr suggested to use Java `long` instead of `int` to store the context id.