### PR TITLE
This should be a min rather than max when compute the resize ratio

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DownsampleUtil.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DownsampleUtil.java
@@ -78,7 +78,7 @@ public class DownsampleUtil {
 
     final float widthRatio = ((float) resizeOptions.width) / widthAfterRotation;
     final float heightRatio = ((float) resizeOptions.height) / heightAfterRotation;
-    float ratio = Math.max(widthRatio, heightRatio);
+    float ratio = Math.min(widthRatio, heightRatio);
     FLog.v(
         "DownsampleUtil",
         "Downsample - Specified size: %dx%d, image size: %dx%d " +


### PR DESCRIPTION
This should be a min rather than max. For example, a 2000 * 1000 image with resize option 200*200, using max, the result will be 400*200. But when the user gives a 200*200 contraint, the expected result should be 200*100.