### PR TITLE
Fix the null pointer exception

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -189,8 +189,14 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
         return null;
       }
       String originalSize = encodedImage.getWidth() + "x" + encodedImage.getHeight();
-      String requestedSize =
-          imageRequest.getResizeOptions().width + "x" + imageRequest.getResizeOptions().height;
+
+      String requestedSize;
+      if (imageRequest.getResizeOptions() != null) {
+        requestedSize = imageRequest.getResizeOptions().width + "x" + imageRequest.getResizeOptions().height;
+      } else {
+        requestedSize = "-1x-1";
+      }
+
       String fraction = numerator > 0 ? numerator + "/8" : "";
       return ImmutableMap.of(
           ORIGINAL_SIZE_KEY, originalSize,
@@ -216,9 +222,14 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
   }
 
   @VisibleForTesting static float determineResizeRatio(
-      ResizeOptions resizeOptions,
-      int width,
-      int height) {
+          ResizeOptions resizeOptions,
+          int width,
+          int height) {
+
+    if (resizeOptions == null) {
+      return 1.0f;
+    }
+
     final float widthRatio = ((float) resizeOptions.width) / width;
     final float heightRatio = ((float) resizeOptions.height) / height;
     float ratio = Math.max(widthRatio, heightRatio);


### PR DESCRIPTION
When a image is rotated and the image request does not specify a resized option, the doTransform() function in ResizeAndRotateProducer will be called. getExtraMap() function will try to access the resized options without checking whether it is null and this causes the Null pointer exception and the image fails to load.