### PR TITLE
Check to make sure padding is not null

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/drawable/ForwardingDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/ForwardingDrawable.java
@@ -157,6 +157,9 @@ public abstract class ForwardingDrawable extends Drawable
 
   @Override
   public Drawable mutate() {
+    if (!mCurrentDelegate.getPadding()) {
+      mCurrentDelegate.setPadding(new RectF());
+    }
     mCurrentDelegate.mutate();
     return this;
   }


### PR DESCRIPTION
I have signed CLA. This fixes issue in 4.1.2 of Android where .mutate() sets null padding, crashing app. Checking for true/false here will fix the issue.

http://grepcode.com/file_/repository.grepcode.com/java/ext/com.google.android/android/4.1.2_r1/android/graphics/drawable/ShapeDrawable.java#188

See https://github.com/facebook/fresco/issues/501
