### PR TITLE
Set default placeholder scaleType if none is provided

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -151,6 +151,7 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   private final int mFailureImageIndex;
   private final int mControllerOverlayIndex;
 
+  private ScaleType mPlaceHolderScaleType;
   private RoundingParams mRoundingParams;
 
   GenericDraweeHierarchy(GenericDraweeHierarchyBuilder builder) {
@@ -173,9 +174,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
         mRoundingParams,
         mResources,
         placeholderImageBranch);
+    mPlaceHolderScaleType = builder.getPlaceholderImageScaleType();
+    if (mPlaceHolderScaleType == null) {
+        mPlaceHolderScaleType = GenericDraweeHierarchyBuilder.DEFAULT_SCALE_TYPE;
+    }
     placeholderImageBranch = maybeWrapWithScaleType(
-        placeholderImageBranch,
-        builder.getPlaceholderImageScaleType());
+            placeholderImageBranch,
+            mPlaceHolderScaleType);
     mPlaceholderImageIndex = numLayers++;
 
     // actual image branch
@@ -640,6 +645,7 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
       drawable = getEmptyPlaceholderDrawable();
     }
     drawable = maybeApplyRoundingBitmapOnly(mRoundingParams, mResources, drawable);
+    maybeWrapWithScaleType(drawable, mPlaceHolderScaleType);
     setLayerChildDrawable(mPlaceholderImageIndex, drawable);
   }
 


### PR DESCRIPTION
This is a bug fix if we want to use the setPlaceHolderImage in GenericDraweeHierarchy to set a place holder image.
Sometimes, we need to set the placeHolder in DraweeHierarchy. But if
we never set the placeHolder before, the setPlaceholderImage would not
set the scaleType. This fix added a default scale type when we set the
place holder image in code.