### PR TITLE
call isFinished() early to avoid race condition in BaseDataSubscriber

### DIFF
--- a/fbcore/src/main/java/com/facebook/datasource/BaseDataSubscriber.java
+++ b/fbcore/src/main/java/com/facebook/datasource/BaseDataSubscriber.java
@@ -39,10 +39,14 @@ public abstract class BaseDataSubscriber<T> implements DataSubscriber<T> {
 
   @Override
   public void onNewResult(DataSource<T> dataSource) {
+    // isFinished() should be checked before calling onNewResultImpl(), otherwise there would be a race condition:
+    // the final data source result might be ready before we call isFinished() here, which would lead
+    // to the loss of the final result (because of an early dataSource.close() call).
+    final boolean shouldClose = dataSource.isFinished();
     try {
       onNewResultImpl(dataSource);
     } finally {
-      if (dataSource.isFinished()) {
+      if (shouldClose) {
         dataSource.close();
       }
     }


### PR DESCRIPTION
This is a fix for the following race condition:
1. Build a controller with a custom increasing quality data source supplier which initiates higher-quality requests after lower-quality ones are completed, in sequence;
2. Call setController() to start image loading;
3. A lower-quality image is received. A higher-quality request is started;
4. Control reaches BaseDataSubscriber.onNewResult() in UI thread. BaseDataSubscriber.onNewResultImpl() is called for the lower-quality image. UI thread is at BaseDataSourceSubscriber.java:44, right after the call to onNewResutImpl().
5. A higher-quality image is received, which is the final result. In a fresco request processing thread, a "finished" flag is set in the data source object.
6. dataSource.isFinished() is called in UI thread, returns true (BaseDataSourceSubscriber.java:45);
7. dataSource.close() is called in UI thread (BaseDataSourceSubscriber.java:46). Hence, the final result is released before we've had a chance to process it in app code;
8. When we get to reporting the final result in UI thread, dataSource.hasResult() returns false, which leads to calling onFailure() callback, as if the request had failed.