### PR TITLE
Remove + modifier to maven dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Fresco supports Android 2.3 (Gingerbread) and later.
 If you are building with Gradle, simply add the following line to the `dependencies` section of your `build.gradle` file:
 
 ```groovy
-compile 'com.facebook.fresco:fresco:0.7.0+'
+compile 'com.facebook.fresco:fresco:0.7.0'
 ```
 
 For full details, visit the documentation on our web site, available in English, Chinese, and Korean:


### PR DESCRIPTION
To keep builds deterministic, we should keep the dependency versions static