### PR TITLE
Fix for OkHttp backend caching 404 responses as images

### DIFF
--- a/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
@@ -109,6 +109,7 @@ public class OkHttpNetworkFetcher extends
             fetchState.responseTime = SystemClock.elapsedRealtime();
             if (!response.isSuccessful()) {
               handleException(call, new IOException("Unexpected HTTP code " + response), callback);
+              return;
             }
             final ResponseBody body = response.body();
             try {

--- a/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
@@ -107,6 +107,9 @@ public class OkHttpNetworkFetcher extends
           @Override
           public void onResponse(Response response) {
             fetchState.responseTime = SystemClock.elapsedRealtime();
+            if (!response.isSuccessful()) {
+              handleException(call, new IOException("Unexpected HTTP code " + response), callback);
+            }
             final ResponseBody body = response.body();
             try {
               long contentLength = body.contentLength();


### PR DESCRIPTION
Issue link: https://github.com/facebook/fresco/issues/736
Unless the response is successful, I am treating it as a normal exception.

According to OkHttp documentation, onResponse is called if comunication with the server resulted in a response (meaning no IO problems): http://square.github.io/okhttp/2.x/okhttp/com/squareup/okhttp/Callback.html#onResponse-com.squareup.okhttp.Response-
This means that we need to handle non-200 responses in onResponse, since a 404 from the server is still a response. The issue describes fresco caching 404 responses, for instance.