### PR TITLE
When using RoundingParams, placeholder image no longer loses Paint properties

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/drawable/RoundedBitmapDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/RoundedBitmapDrawable.java
@@ -49,7 +49,7 @@ public class RoundedBitmapDrawable extends BitmapDrawable
   private final Path mPath = new Path();
   private boolean mIsPathDirty = true;
   /** True if this rounded bitmap drawable will actually do anything. */
-  private final Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+  private final Paint mPaint;
   private final Paint mBorderPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
   private boolean mIsShaderTransformDirty = true;
   private WeakReference<Bitmap> mLastBitmap;
@@ -57,7 +57,17 @@ public class RoundedBitmapDrawable extends BitmapDrawable
   private @Nullable TransformCallback mTransformCallback;
 
   public RoundedBitmapDrawable(Resources res, Bitmap bitmap) {
+    this(res, bitmap, null);
+  }
+
+  public RoundedBitmapDrawable(Resources res, Bitmap bitmap, Paint paint){
     super(res, bitmap);
+    if (paint == null){
+      mPaint = new Paint();
+    }else{
+      mPaint = new Paint(paint);
+    }
+    mPaint.setFlags(Paint.ANTI_ALIAS_FLAG);
     mBorderPaint.setStyle(Paint.Style.STROKE);
   }
 
@@ -70,7 +80,7 @@ public class RoundedBitmapDrawable extends BitmapDrawable
   public static RoundedBitmapDrawable fromBitmapDrawable(
       Resources res,
       BitmapDrawable bitmapDrawable) {
-    return new RoundedBitmapDrawable(res, bitmapDrawable.getBitmap());
+    return new RoundedBitmapDrawable(res, bitmapDrawable.getBitmap(), bitmapDrawable.getPaint());
   }
 
   /**

--- a/drawee/src/test/java/com/facebook/drawee/drawable/RoundedBitmapDrawableTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/drawable/RoundedBitmapDrawableTest.java
@@ -12,7 +12,10 @@ package com.facebook.drawee.drawable;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.ColorFilter;
 import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.DisplayMetrics;
 
@@ -106,5 +109,21 @@ public class RoundedBitmapDrawableTest {
     mRoundedBitmapDrawable.setCircle(false);
     mRoundedBitmapDrawable.draw(mCanvas);
     assertFalse(mRoundedBitmapDrawable.mIsNonzero);
+  }
+
+  @Test
+  public void testPreservePaintOnDrawableCopy() {
+    ColorFilter colorFilter = mock(ColorFilter.class);
+    Paint originalPaint = mock(Paint.class);
+    BitmapDrawable originalVersion = mock(BitmapDrawable.class);
+
+    originalPaint.setColorFilter(colorFilter);
+    when(originalVersion.getPaint()).thenReturn(originalPaint);
+
+    RoundedBitmapDrawable roundedVersion = RoundedBitmapDrawable.fromBitmapDrawable(mResources,
+            originalVersion);
+
+    assertEquals(originalVersion.getPaint().getColorFilter(),
+            roundedVersion.getPaint().getColorFilter());
   }
 }


### PR DESCRIPTION
Fix for this issue: https://github.com/facebook/fresco/issues/511

When constructing a new RoundedBitmapDrawable from a source BitmapDrawable, any modifications done on the Paint of the original BitmapDrawable get lost because only the Bitmap is transmitted along.
I have created another constructor for RoundedBitmapDrawable that accepts a Paint object, so that mPaint can be created as a copy of it.
I also wrote a new test that reproduces issue #511 - that is now passing and was not before.