### PR TITLE
Two fixed typos in Java source files.

### DIFF
--- a/fbcore/src/main/java/com/facebook/common/internal/ImmutableList.java
+++ b/fbcore/src/main/java/com/facebook/common/internal/ImmutableList.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 /**
  * A dummy representation of an immutable set. This can be used temporarily as a type until we have
- * an actual non-gauva implementation.
+ * an actual non-guava implementation.
  */
 public class ImmutableList<E> extends ArrayList<E> {
 

--- a/imagepipeline/src/main/java/com/facebook/imageutils/StreamProcessor.java
+++ b/imagepipeline/src/main/java/com/facebook/imageutils/StreamProcessor.java
@@ -23,7 +23,7 @@ class StreamProcessor {
    *  @param is the input stream to read bytes from
    *  @param numBytes the number of bytes to read
    *  @param isLittleEndian whether the bytes should be interpreted in little or big endian format
-   *  @return packed int read from input stream and constructed according to endianess
+   *  @return packed int read from input stream and constructed according to endianness
    */
   public static int readPackedInt(InputStream is, int numBytes, boolean isLittleEndian)
       throws IOException {


### PR DESCRIPTION
In StreamProcessor.java was a misspelling of the word "endianness" in a Javadoc comment. Also, a misspelling of the term "guava" used in the word "non-guava" in a comment in ImmutableList.java.