### PR TITLE
Fix typo in 01-using-drawees-code.md

### DIFF
--- a/docs/01-using-drawees-code.md
+++ b/docs/01-using-drawees-code.md
@@ -9,7 +9,7 @@ next: drawee-branches.html
 
 ### Setting the actual image
 
-The easy to way is to call 
+The easy way is to call 
 
 ```java
 mSimpleDraweeView.setImageURI(uri);


### PR DESCRIPTION
Removed superfluous word in first section of [docs/01-using-drawees-code.md](https://github.com/facebook/fresco/tree/gh-pages/docs/01-using-drawees-code.md).