### PR TITLE
Fix for #912 Not able to set hotspot on "overlayImage" drawable set i…

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/drawable/ArrayDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/ArrayDrawable.java
@@ -376,7 +376,8 @@ public class ArrayDrawable extends Drawable
   @Override
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public void setHotspot(float x, float y) {
-    for (Drawable drawable : mLayers) {
+    for (int i = 0; i < mLayers.length; i++) {
+      Drawable drawable = mLayers[i];
       if (drawable != null) {
         drawable.setHotspot(x, y);
       }

--- a/drawee/src/main/java/com/facebook/drawee/drawable/ArrayDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/ArrayDrawable.java
@@ -11,6 +11,7 @@ package com.facebook.drawee.drawable;
 
 import javax.annotation.Nullable;
 
+import android.annotation.TargetApi;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Matrix;
@@ -18,6 +19,7 @@ import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 
 import com.facebook.common.internal.Preconditions;
 
@@ -368,6 +370,16 @@ public class ArrayDrawable extends Drawable
       mTransformCallback.getRootBounds(bounds);
     } else {
       bounds.set(getBounds());
+    }
+  }
+
+  @Override
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public void setHotspot(float x, float y) {
+    for (Drawable drawable : mLayers) {
+      if (drawable != null) {
+        drawable.setHotspot(x, y);
+      }
     }
   }
 }

--- a/drawee/src/main/java/com/facebook/drawee/drawable/ForwardingDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/ForwardingDrawable.java
@@ -9,12 +9,14 @@
 
 package com.facebook.drawee.drawable;
 
+import android.annotation.TargetApi;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 
 /**
  * A forwarding drawable class - the goal is to forward (delegate) drawable functionality to an
@@ -237,5 +239,11 @@ public class ForwardingDrawable extends Drawable
     // because the parent may have to change our bounds.
     outBounds.set(getBounds());
     sTempTransform.mapRect(outBounds);
+  }
+
+  @Override
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public void setHotspot(float x, float y) {
+    mCurrentDelegate.setHotspot(x, y);
   }
 }


### PR DESCRIPTION
…n xml

- Overridden setHotspot(float x, float y)  method in ForwardingDrawablea and ArrayDrawable for passing touch event to drawee layers to make ripple hot spot work with SimpleDraweeView "overlayImage" attribute.