### PR TITLE
Fix leaked reference in LocalExifThumbnailProducer.buildEncodedImage()

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducer.java
@@ -124,7 +124,13 @@ public class LocalExifThumbnailProducer implements Producer<EncodedImage> {
     int rotationAngle = getRotationAngle(exifInterface);
     int width = dimensions != null ? dimensions.first : EncodedImage.UNKNOWN_WIDTH;
     int height = dimensions != null ? dimensions.second : EncodedImage.UNKNOWN_HEIGHT;
-    EncodedImage encodedImage = new EncodedImage(CloseableReference.of(imageBytes));
+    EncodedImage encodedImage;
+    CloseableReference<PooledByteBuffer> closeableByteBuffer = CloseableReference.of(imageBytes);
+    try {
+      encodedImage = new EncodedImage(closeableByteBuffer);
+    } finally {
+      CloseableReference.closeSafely(closeableByteBuffer);
+    }
     encodedImage.setImageFormat(ImageFormat.JPEG);
     encodedImage.setRotationAngle(rotationAngle);
     encodedImage.setWidth(width);

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducerTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducerTest.java
@@ -116,11 +116,10 @@ public class LocalExifThumbnailProducerTest {
   public void testFindExifThumbnail() {
     mTestLocalExifThumbnailProducer.produceResults(mConsumer, mProducerContext);
     mTestExecutorService.runUntilIdle();
-    // Should have 3 references open: The reference that is used in the producer, the cloned
-    // reference when the argument is captured and one more that is created when getByteBufferRef is
-    // called on EncodedImage
+    // Should have 2 references open: The cloned reference when the argument is captured by EncodedImage
+    // and the one that is created when getByteBufferRef is called on EncodedImage
     assertEquals(
-        3,
+        2,
         mCapturedEncodedImage.
             getByteBufferRef().getUnderlyingReferenceTestOnly().getRefCountTestOnly());
     assertSame(mThumbnailByteBuffer, mCapturedEncodedImage.getByteBufferRef().get());


### PR DESCRIPTION
Closes https://github.com/facebook/fresco/issues/314

The original reference is not closed explicitly and gets closed when garbage-collected.  The following test proves that:
```java
  @Test
  public void testFindExifThumbnail() {
    mTestLocalExifThumbnailProducer.produceResults(mConsumer, mProducerContext);
    mTestExecutorService.runUntilIdle();
    // Should have 3 references open: The reference that is used in the producer, the cloned
    // reference when the argument is captured and one more that is created when getByteBufferRef is
    // called on EncodedImage
    assertEquals(
        3,
        mCapturedEncodedImage.
            getByteBufferRef().getUnderlyingReferenceTestOnly().getRefCountTestOnly());
    
    //////////////////////////////////////////
    // garbage collection test
    System.gc();
    try {
      Thread.sleep(1000);
    } catch (Exception e) {
    }
    assertEquals(
        2,
        mCapturedEncodedImage.
            getByteBufferRef().getUnderlyingReferenceTestOnly().getRefCountTestOnly());
    //////////////////////////////////////////

    assertSame(mThumbnailByteBuffer, mCapturedEncodedImage.getByteBufferRef().get());
    assertEquals(ImageFormat.JPEG, mCapturedEncodedImage.getImageFormat());
    assertEquals(WIDTH, mCapturedEncodedImage.getWidth());
    assertEquals(HEIGHT, mCapturedEncodedImage.getHeight());
    assertEquals(ANGLE, mCapturedEncodedImage.getRotationAngle());
  }
```java