### PR TITLE
add attr placeholderImageUri

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
@@ -13,12 +13,14 @@ import javax.annotation.Nullable;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.net.Uri;
 import android.os.Build;
 import android.util.AttributeSet;
 
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.internal.Supplier;
+import com.facebook.drawee.R;
 import com.facebook.drawee.generic.GenericDraweeHierarchy;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.interfaces.SimpleDraweeControllerBuilder;
@@ -48,31 +50,31 @@ public class SimpleDraweeView extends GenericDraweeView {
 
   public SimpleDraweeView(Context context, GenericDraweeHierarchy hierarchy) {
     super(context, hierarchy);
-    init();
+    init(context, null);
   }
 
   public SimpleDraweeView(Context context) {
     super(context);
-    init();
+    init(context, null);
   }
 
   public SimpleDraweeView(Context context, AttributeSet attrs) {
     super(context, attrs);
-    init();
+    init(context, attrs);
   }
 
   public SimpleDraweeView(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
-    init();
+    init(context, attrs);
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   public SimpleDraweeView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
     super(context, attrs, defStyleAttr, defStyleRes);
-    init();
+    init(context, attrs);
   }
 
-  private void init() {
+  private void init(Context context, @Nullable AttributeSet attrs) {
     if (isInEditMode()) {
       return;
     }
@@ -80,6 +82,19 @@ public class SimpleDraweeView extends GenericDraweeView {
         sDraweeControllerBuilderSupplier,
         "SimpleDraweeView was not initialized!");
     mSimpleDraweeControllerBuilder = sDraweeControllerBuilderSupplier.get();
+
+    if (attrs != null) {
+      TypedArray gdhAttrs = context.obtainStyledAttributes(
+          attrs,
+          R.styleable.SimpleDraweeView);
+      try {
+        if(gdhAttrs.hasValue(R.styleable.SimpleDraweeView_actualImageUri)) {
+          setImageURI(Uri.parse(gdhAttrs.getString(R.styleable.SimpleDraweeView_actualImageUri)), null);
+        }
+      } finally {
+        gdhAttrs.recycle();
+      }
+    }
   }
 
   protected SimpleDraweeControllerBuilder getControllerBuilder() {

--- a/drawee/src/main/res/values/attrs.xml
+++ b/drawee/src/main/res/values/attrs.xml
@@ -123,4 +123,12 @@
     <attr name="roundingBorderPadding" format="dimension" />
 
   </declare-styleable>
+
+  <declare-styleable name="SimpleDraweeView">
+
+    <!-- An image uri . -->
+    <attr name="actualImageUri" format="string"/>
+
+  </declare-styleable>
+
 </resources>

--- a/samples/demo/src/main/res/layout/activity_main.xml
+++ b/samples/demo/src/main/res/layout/activity_main.xml
@@ -67,6 +67,19 @@
         style="@style/label"
         />
     </FrameLayout>
+
+    <FrameLayout style="@style/sample_layout">
+      <com.facebook.drawee.view.SimpleDraweeView
+        android:id="@+id/attr_image_url"
+        style="@style/drawee"
+        fresco:actualImageUri="http://frescolib.org/static/favicon.png"
+        />
+
+      <TextView
+        android:text="@string/label_attr_image_uri"
+        style="@style/label"
+        />
+    </FrameLayout>
   </LinearLayout>
 
   <View
@@ -127,6 +140,36 @@
 
       <TextView
         android:text="@string/label_one_loop_animated_webp"
+        style="@style/label"
+        />
+    </FrameLayout>
+
+    <FrameLayout style="@style/sample_layout">
+      <com.facebook.drawee.view.SimpleDraweeView
+        android:id="@+id/attr_image_data"
+        style="@style/drawee"
+        fresco:actualImageUri="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAEZ0l
+        EQVR42u2bWUgVURjHzXZoxyyQqMhKbRdbsDBte7BsoaiwMkMyKoQi9fYSRA9hGq0PESRmD1kQZWELbWALQRFYUUFEaVC
+        0WCZlmqbT/4tv4uM0c+cGLbM9/LnO3P+9nvPzzJlvGcM0TQvzssJ8AD4AH4APwAfgA/AB/HE1z+sYCZVAd6F4C280dBq
+        6CkVZeBOgSqgcmmNLABjYNOgJpLHyg3iXQK+EN83E1w7KgeqF94itAGBAnaGt0FcxSFKugbcndEDxkWYbeKOgEwbew7Y
+        BgMEMgy6LwTVALUYAcDwRuie8n6A2IwB0DD3j99rYq3+u5L8DwCB6QOnQWzGwW9Bi6I0EgNf20Cbos/CehDLVFcCrqRD
+        6Jt7bAwXsBuCQsizpuAs0GPqgAFgvfM10ufD5RAMAu8S5Oiibz2fbDYBc9huUS6JOAVDEx43QQuFNFt+RyufO8TGtogT
+        hXWs3ABd4MK3QcAsABXxcTbdJCwDl+uWk/D7bAqANanSIAF5A/UMEcMepACi4eR8igMTfALDaKQDm8kb3MxAKAiBHTGq
+        OBYB9tgqElD1gBJ/bqNzq1hgAoFA5HNrJn9W9yQqA2yK0Pip89Jn9dgJA0d8MqFQMku7he6GuCoCn0FSO/TXx+YD4Xh3
+        ADWgy9Eh4a6FVUISdALQowdBLaJHi1QF8gd4J70MoSfHqAOqV+P8mNNI22aAAIHUeGmTgLTDwlhr9JQUATewxhfpqshM
+        AGQhRgLOZr216L4VvW93YWyi8FCVmsY80H8qAOrD3rPBWm2WJdgCQy6lvFV/XdK4TtE3cBfRNMBV6DV2DRrFXzQqTRch
+        LkE5BA21bEOEEpzcnRXQcC11Rlq/c3PrSMmbvBOi+4k1jH62ifpQUOaYihMEuVzZCzSQdJmh5nDJb1gNsD4BXQLGYBO3
+        yZWo2yF7KEs8IL0WLx0Qs4CwAnMvLZUzX+AKeaK0SCo/nIEj3PobGcZ1PcyqAi2LwVKyMDiEZ0jiqizRIhhwHQMYB8Rb
+        Z4A4RJEWZZIOOBdAqIzSLFVBDO7zbAKjZ4FCDkphZNpjkRgCxIoa3AjDTVQAocoMqxKTyzADgdQx3j4I2RpwAgFLfIRz
+        /14gJ0c9jFQDPOb+nlPaj8FZZtcbsDKCRgx9ZCKmQWaEAQK2w46JxonEg1cdxzVGTdJhg5FM/L4R0mOoCmY7tDmPwl5Q
+        JPeAiZxg3SCKEt0jxXofiHN0eV+p0P5YxTz6Os0Ja7inszRf7xfa/nen9KwAU86+k8pcobmQoJa8Ae7tD66BZrnxAgv/
+        6xVbpsCufEMEkpyiVW+rpNbkeACY3gOuATWLyVMaarrbH3QqgTKntbxGtsTovAJC3wfRg2aBbAch0OMbLACzb414D8Et
+        73GsAssSTXwHP7AH8QONuMXnSCi8AoDhgqdIVauDWWbhXVoCsBVCvYJLrH5Y2qQcchHp54mlxJRCi0HeZpx6X51S4kh9
+        sjPH/X8AH4APwAfgAfAA+AB+AU/Qd42W8mKN4nlcAAAAASUVORK5CYII="
+        />
+
+      <TextView
+        android:text="@string/label_attr_image_uri"
         style="@style/label"
         />
     </FrameLayout>

--- a/samples/demo/src/main/res/values/strings.xml
+++ b/samples/demo/src/main/res/values/strings.xml
@@ -8,4 +8,5 @@
   <string name="label_animated_webp">Animated webp</string>
   <string name="label_one_loop_animated_webp">Animated webp (1 loop)</string>
   <string name="label_data_webp">Webp (data uri)</string>
+  <string name="label_attr_image_uri">Attribute actualImageUri</string>
 </resources>


### PR DESCRIPTION
add attr placeholderImageUri and demo

can write image uri directly like this 

```xml
    <com.facebook.drawee.view.SimpleDraweeView
        android:id="@+id/placeholderImageUri"
        android:layout_width="match_parent"
        android:layout_height="0dp"
        android:layout_weight="1"
        fresco:actualImageScaleType="fitCenter"
        fresco:placeholderImageUri="http://www.smemo.info/icon.png" />
```

when we use android databinding ,like this

```xml
    <com.facebook.drawee.view.SimpleDraweeView
        android:id="@+id/placeholderImageUri"
        android:layout_width="match_parent"
        android:layout_height="0dp"
        android:layout_weight="1"
        fresco:actualImageScaleType="fitCenter"
        fresco:placeholderImageUri="@{imageBean.imageUrl}" />
```