### PR TITLE
Changed ArrayList to ArrayDeque so that the runnables are FIFO-ed

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThreadHandoffProducerQueue.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThreadHandoffProducerQueue.java
@@ -16,44 +16,44 @@ import java.util.Deque;
 import java.util.concurrent.Executor;
 
 public class ThreadHandoffProducerQueue {
-    private boolean mQueueing = false;
-    private final Deque<Runnable> mRunnableList;
-    private final Executor mExecutor;
+  private boolean mQueueing = false;
+  private final Deque<Runnable> mRunnableList;
+  private final Executor mExecutor;
 
-    public ThreadHandoffProducerQueue(Executor executor) {
-        mExecutor = Preconditions.checkNotNull(executor);
-        mRunnableList = new ArrayDeque<>();
+  public ThreadHandoffProducerQueue(Executor executor) {
+    mExecutor = Preconditions.checkNotNull(executor);
+    mRunnableList = new ArrayDeque<>();
+  }
+
+
+  public synchronized void addToQueueOrExecute(Runnable runnable) {
+    if (mQueueing) {
+      mRunnableList.add(runnable);
+    } else {
+      mExecutor.execute(runnable);
     }
+  }
 
+  public synchronized void startQueueing() {
+    mQueueing = true;
+  }
 
-    public synchronized void addToQueueOrExecute(Runnable runnable) {
-        if (mQueueing) {
-            mRunnableList.add(runnable);
-        } else {
-            mExecutor.execute(runnable);
-        }
-    }
+  public synchronized void stopQueuing() {
+    mQueueing = false;
+    execInQueue();
+  }
 
-    public synchronized void startQueueing() {
-        mQueueing = true;
-    }
+  private void execInQueue() {
+    while (!mRunnableList.isEmpty())
+      mExecutor.execute(mRunnableList.pop());
+    mRunnableList.clear();
+  }
 
-    public synchronized void stopQueuing() {
-        mQueueing = false;
-        execInQueue();
-    }
+  public synchronized void remove(Runnable runnable) {
+    mRunnableList.remove(runnable);
+  }
 
-    private void execInQueue() {
-        while (!mRunnableList.isEmpty())
-            mExecutor.execute(mRunnableList.pop());
-        mRunnableList.clear();
-    }
-
-    public synchronized void remove(Runnable runnable) {
-        mRunnableList.remove(runnable);
-    }
-
-    public synchronized boolean isQueueing() {
-        return mQueueing;
-    }
+  public synchronized boolean isQueueing() {
+    return mQueueing;
+  }
 }


### PR DESCRIPTION
So this is based on the discussion in #512 

Consider a list of network fetched images:
 - When the user pauses,you want the image that he is current viewing to be loaded first.
 - Currently since the methods are synchronized,it would not make sense implementing Thread Safety.
 - However if you plan to make this multi-threaded ,I can work on the thread safe implementation here(I would be implementing a multi thread environment for my purpose).
 - I realize the change is pretty negligible :) ,sorry about that.