### PR TITLE
Added support for synchronous disk cache check

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
@@ -125,6 +125,32 @@ public class BufferedDiskCache {
   }
 
   /**
+   * Performs disk cache check synchronously.
+   * @param key
+   * @return true if the key is found in disk cache else false
+   */
+  public boolean syncDiskCheck(final CacheKey key){
+    if(containsSync(key)){
+      return true;
+    }
+    EncodedImage result = mStagingArea.get(key);
+    if (result != null) {
+      result.close();
+      FLog.v(TAG, "Found image for %s in staging area", key.toString());
+      mImageCacheStatsTracker.onStagingAreaHit();
+      return true;
+    } else {
+      FLog.v(TAG, "Did not find image for %s in staging area", key.toString());
+      mImageCacheStatsTracker.onStagingAreaMiss();
+      try {
+        return mFileCache.hasKey(key);
+      } catch (Exception exception) {
+        return false;
+      }
+    }
+  }
+
+  /**
    * Performs key-value look up in disk cache. If value is not found in disk cache staging area
    * then disk cache read is scheduled on background thread. Any error manifests itself as
    * cache miss, i.e. the returned task resolves to null.

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
@@ -116,7 +116,7 @@ public class BufferedDiskCache {
    * @return true if the key is found in disk cache else false
    */
   public boolean syncDiskCheck(final CacheKey key) {
-    if(containsSync(key)){
+    if(containsSync(key)) {
       return true;
     }
     return checkInStagingAreaAndFileCache(key);

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
@@ -94,21 +94,7 @@ public class BufferedDiskCache {
           new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
-              EncodedImage result = mStagingArea.get(key);
-              if (result != null) {
-                result.close();
-                FLog.v(TAG, "Found image for %s in staging area", key.toString());
-                mImageCacheStatsTracker.onStagingAreaHit();
-                return true;
-              } else {
-                FLog.v(TAG, "Did not find image for %s in staging area", key.toString());
-                mImageCacheStatsTracker.onStagingAreaMiss();
-                try {
-                  return mFileCache.hasKey(key);
-                } catch (Exception exception) {
-                  return false;
-                }
-              }
+              return checkInStagingAreaAndFileCache(key);
             }
           },
           mReadExecutor);
@@ -129,25 +115,11 @@ public class BufferedDiskCache {
    * @param key
    * @return true if the key is found in disk cache else false
    */
-  public boolean syncDiskCheck(final CacheKey key){
+  public boolean syncDiskCheck(final CacheKey key) {
     if(containsSync(key)){
       return true;
     }
-    EncodedImage result = mStagingArea.get(key);
-    if (result != null) {
-      result.close();
-      FLog.v(TAG, "Found image for %s in staging area", key.toString());
-      mImageCacheStatsTracker.onStagingAreaHit();
-      return true;
-    } else {
-      FLog.v(TAG, "Did not find image for %s in staging area", key.toString());
-      mImageCacheStatsTracker.onStagingAreaMiss();
-      try {
-        return mFileCache.hasKey(key);
-      } catch (Exception exception) {
-        return false;
-      }
-    }
+    return checkInStagingAreaAndFileCache(key);
   }
 
   /**
@@ -164,6 +136,30 @@ public class BufferedDiskCache {
       return foundPinnedImage(key, pinnedImage);
     }
     return getAsync(key, isCancelled);
+  }
+
+  /**
+   * Performs key-value loop up in staging area and file cache.
+   * Any error manifests itself as a miss, i.e. returns false.
+   * @param key
+   * @return true if the image is found in staging area or File cache, false if not found
+   */
+  private boolean checkInStagingAreaAndFileCache(final CacheKey key) {
+    EncodedImage result = mStagingArea.get(key);
+    if (result != null) {
+      result.close();
+      FLog.v(TAG, "Found image for %s in staging area", key.toString());
+      mImageCacheStatsTracker.onStagingAreaHit();
+      return true;
+    } else {
+      FLog.v(TAG, "Did not find image for %s in staging area", key.toString());
+      mImageCacheStatsTracker.onStagingAreaMiss();
+      try {
+        return mFileCache.hasKey(key);
+      } catch (Exception exception) {
+        return false;
+      }
+    }
   }
 
   private Task<EncodedImage> getAsync(final CacheKey key, final AtomicBoolean isCancelled) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -391,6 +391,28 @@ public class ImagePipeline {
 
   /**
    * Returns whether the image is stored in the disk cache.
+   * The check is made synchronously
+   * @param uri the uri for the image to be looked up.
+   * @return true if the image was found in the disk cache, false otherwise.
+   */
+  public boolean isInDiskCacheSync(final Uri uri) {
+    return isInDiskCacheSync(ImageRequest.fromUri(uri));
+  }
+
+  /**
+   * Performs disk cache check synchronously. It is not recommended to use this
+   * unless u know what exactly you are doing. Disk cache check is a costly operation,
+   * the call will block the caller thread until the cache check is completed.
+   * @param imageRequest the imageRequest for the image to be looked up.
+   * @return true if the image was found in the disk cache, false otherwise.
+   */
+  public boolean isInDiskCacheSync(final ImageRequest imageRequest) {
+    final CacheKey cacheKey = mCacheKeyFactory.getEncodedCacheKey(imageRequest);
+    return mMainBufferedDiskCache.syncDiskCheck(cacheKey);
+  }
+
+  /**
+   * Returns whether the image is stored in the disk cache.
    *
    * <p>If you have supplied your own cache key factory when configuring the pipeline, this method
    * may not work correctly. It will only work if the custom factory builds the cache key entirely

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -391,7 +391,9 @@ public class ImagePipeline {
 
   /**
    * Returns whether the image is stored in the disk cache.
-   * The check is made synchronously
+   * Performs disk cache check synchronously. It is not recommended to use this
+   * unless you know what exactly you are doing. Disk cache check is a costly operation,
+   * the call will block the caller thread until the cache check is completed.
    * @param uri the uri for the image to be looked up.
    * @return true if the image was found in the disk cache, false otherwise.
    */
@@ -401,7 +403,7 @@ public class ImagePipeline {
 
   /**
    * Performs disk cache check synchronously. It is not recommended to use this
-   * unless u know what exactly you are doing. Disk cache check is a costly operation,
+   * unless you know what exactly you are doing. Disk cache check is a costly operation,
    * the call will block the caller thread until the cache check is completed.
    * @param imageRequest the imageRequest for the image to be looked up.
    * @return true if the image was found in the disk cache, false otherwise.

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/cache/BufferedDiskCacheTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/cache/BufferedDiskCacheTest.java
@@ -135,6 +135,12 @@ public class BufferedDiskCacheTest {
   }
 
   @Test
+  public void testSyncDiskCacheCheck(){
+    when(mStagingArea.containsKey(mCacheKey) || mFileCache.hasKey(mCacheKey)).thenReturn(true);
+    assertTrue(mBufferedDiskCache.syncDiskCheck(mCacheKey));
+  }
+
+  @Test
   public void testQueriesDiskCache() throws Exception {
     when(mFileCache.getResource(eq(mCacheKey))).thenReturn(mBinaryResource);
     Task<EncodedImage> readTask = mBufferedDiskCache.get(mCacheKey, mIsCancelled);


### PR DESCRIPTION
Added a support to check in disk cache synchronously. The call will block the caller thread. 
This is useful when you want to manually check if an image is present in disk cache inside a async callback, this prevents nesting of callbacks.