### PR TITLE
Fixed site root of docs

### DIFF
--- a/_includes/doc.html
+++ b/_includes/doc.html
@@ -1,6 +1,6 @@
 <div class="post">
   <header class="post-header">
-    <h1 class="post-title">{% if include.truncate %}<a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>{% else %}{{ page.title }}{% endif %}</h1>
+    <h1 class="post-title">{% if include.truncate %}<a href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>{% else %}{{ page.title }}{% endif %}</h1>
   </header>
 
   <article class="post-content">
@@ -8,7 +8,7 @@
       {% if page.content contains '<!--truncate-->' %}
         {{ page.content | split:'<!--truncate-->' | first }}
         <div class="read-more">
-          <a href="{{ site.baseurl }}{{ page.url }}" >
+          <a href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" >
             ...Read More
           </a>
         </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,8 +9,8 @@
   <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/static/og_image.png" />
   <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
 
-  <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css" media="screen">
-  <link rel="icon" href="{{ site.baseurl }}/static/favicon.png" type="image/x-icon">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css" media="screen">
+  <link rel="icon" href="{{ site.url }}{{ site.baseurl }}/static/favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
 
   <script src="http://fb.me/react-with-addons-0.13.1.min.js"></script>

--- a/_includes/home_header.html
+++ b/_includes/home_header.html
@@ -15,7 +15,7 @@
         </div>
       </div>
       <div class="projectLogo">
-        <img src="{{ site.baseurl }}/static/logo.png" alt="{{ site.title }}">
+        <img src="{{ site.url }}{{ site.baseurl }}/static/logo.png" alt="{{ site.title }}">
       </div>
     </div>
   </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,8 +1,8 @@
 <div id="fixed_header" class="fixedHeaderContainer{% if include.alwayson %} visible{% endif %}">
   <div class="headerWrapper wrapper">
     <header>
-      <a href="{{ site.baseurl }}/">
-        <img src="{{ site.baseurl }}/static/logo.png">
+      <a href="{{ site.url }}{{ site.baseurl }}/">
+        <img src="{{ site.url }}{{ site.baseurl }}/static/logo.png">
         <h2>{{ site.title }}</h2>
       </a>
 

--- a/_includes/nav_search.html
+++ b/_includes/nav_search.html
@@ -2,4 +2,4 @@
   <input id="search_input" type="search" />
 </li>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
-<script type="text/javascript" src="static/js/docsearch.js"></script>
+<script type="text/javascript" src="{{ site.url }}{{ site.baseurl }}/static/js/docsearch.js"></script>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -9,7 +9,7 @@
     {% if author.full_name %}
     <p class="post-authorName">{{ author.full_name }}</p>
     {% endif %}
-    <h1 class="post-title">{% if include.truncate %}<a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>{% else %}{{ page.title }}{% endif %}</h1>
+    <h1 class="post-title">{% if include.truncate %}<a href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>{% else %}{{ page.title }}{% endif %}</h1>
     <p class="post-meta">Posted {{ page.date | date: '%B %d, %Y' }}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
   </header>
 
@@ -18,7 +18,7 @@
     {% if page.content contains '<!--truncate-->' %}
       {{ page.content | split:'<!--truncate-->' | first | markdownify }}
       <div class="read-more">
-        <a href="{{ site.baseurl }}{{ page.url }}" >
+        <a href="{{ site.url }}{{ site.baseurl }}{{ page.url }}" >
           Read More
         </a>
       </div>

--- a/_includes/react/nav_blog.html
+++ b/_includes/react/nav_blog.html
@@ -5,9 +5,9 @@
       items: [
         {% for post in site.posts limit:10 %}
         {
-          key : "{{ site.baseurl }}{{ post.url }}",
+          key : "{{ site.url }}{{ site.baseurl }}{{ post.url }}",
           title : "{{ post.title }}",
-          url : "{{ site.baseurl }}{{ post.url }}"
+          url : "{{ site.url }}{{ site.baseurl }}{{ post.url }}"
         }{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]
@@ -17,9 +17,9 @@
       items: [
         {% for post in site.posts offset:10 %}
         {
-          key : "{{ site.baseurl }}{{ post.url }}",
+          key : "{{ site.url }}{{ site.baseurl }}{{ post.url }}",
           title : "{{ post.title }}",
-          url : "{{ site.baseurl }}{{ post.url }}"
+          url : "{{ site.url }}{{ site.baseurl }}{{ post.url }}"
         }{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ]

--- a/_includes/react/nav_docs.html
+++ b/_includes/react/nav_docs.html
@@ -14,9 +14,9 @@
           {% endif %}
         {% endfor %}
         {
-          key : "{{ site.baseurl }}{{ doc.url }}",
+          key : "{{ site.url }}{{ site.baseurl }}{{ doc.url }}",
           title : "{{ doc.title }}",
-          url : "{{ site.baseurl }}{{ doc.url }}",
+          url : "{{ site.url }}{{ site.baseurl }}{{ doc.url }}",
         }{% unless forloop.last %},{% endunless %}
         {% endfor %}
       ],

--- a/blog/all.html
+++ b/blog/all.html
@@ -10,7 +10,7 @@ layout: blog
       {% assign author = site.data.authors[post.author] %}
       <p>
         <strong>
-          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+          <a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
         </strong>
           on {{ post.date | date: "%B %e, %Y" }} by {{ author.display_name }}
       </p>


### PR DESCRIPTION
The site was broken when viewed at http://facebook.github.io/fresco so I've ensured the correct macros are being used together.

For context, the following lines appear in `_config.yml`.
```
url: "http://frescolib.org"
baseurl: ""
```