### PR TITLE
Make footer link use site var to repo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
         <a class="footerLink" href="https://twitter.com/fbOpenSource" target="_blank">Twitter</a>
       </div>
       <div class="footerSection rightAlign">
-        <a class="footerLink" href="https://github.com/facebook/fresco/" target="_blank">Contribute to this project on GitHub</a>
+        <a class="footerLink" href="https://github.com/{{ site.ghrepo }}" target="_blank">Contribute to this project on GitHub</a>
       </div>
     </div>
   </div>
@@ -31,4 +31,3 @@
   ga('create', '{{ site.gacode }}', 'auto');
   ga('send', 'pageview');
 </script>
-


### PR DESCRIPTION
This changes the footer link to GitHub to use the variable defined in `_config.yml`.