### PR TITLE
Restore edit links to docs

### DIFF
--- a/_includes/doc.html
+++ b/_includes/doc.html
@@ -17,6 +17,8 @@
       {% endif %}
     {% else %}
       {{ content }}
+
+      <p><a class="edit-page-link" href="https://github.com/{{ site.ghrepo }}/tree/gh-pages/{{ page.path }}" target="_blank">Edit on GitHub</a></p>
     {% endif %}
   </article>
   {% include doc_paging.html %}

--- a/_sass/_buttons.scss
+++ b/_sass/_buttons.scss
@@ -32,3 +32,16 @@
 .blockButton {
   display: block;
 }
+
+.edit-page-link {
+    float: right;
+    font-size: 14px;
+    font-weight: normal;
+    line-height: 20px;
+    opacity: 0.6;
+    transition: opacity 0.5s;
+}
+
+.edit-page-link:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
This PR restores the edit button so that someone can easily amend the docs in GitHub.