### PR TITLE
Updated docs for launch of 0.10.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ description: >
 timezone: America/Los_Angeles
 ghrepo: "facebook/fresco"
 
-current_version: 0.9.0
+current_version: 0.10.0
 
 markdown: kramdown
 kramdown:

--- a/_docs/00-index.md
+++ b/_docs/00-index.md
@@ -12,11 +12,29 @@ Here's how to add Fresco to your Android project.
 
 Edit your `build.gradle` file. You must add the following line to the `dependencies` section:
 
-
 ```groovy
 dependencies {
   // your app's other dependencies
   compile 'com.facebook.fresco:fresco:{{site.current_version}}+'
+}
+```
+
+The following optional modules may also be added, depending on the needs of your app.
+
+```groovy
+dependencies {
+  // If your app supports Android versions before Ice Cream Sandwich
+  compile 'com.facebook.fresco:animated-base-support:{{site.current_version}}+'
+
+  // For animated gif support
+  compile 'com.facebook.fresco:animated-gif:{{site.current_version}}+'
+
+  // For webp support, including animated webp
+  compile 'com.facebook.fresco:animated-webp:{{site.current_version}}+'
+  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}+'
+
+  // For webp support, without animations
+  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}+'
 }
 ```
 
@@ -29,7 +47,7 @@ When you expand it, it will create a directory called 'frescolib'. Note the loca
 1. From the File menu, choose Import.
 2. Expand Android, select "Existing Android Code into Workspace", and click Next.
 3. Click Browse, navigate to the frescolib directory, and click OK.
-4. Five projects should be added: drawee, fbcore, fresco, imagepipeline, and imagepipeline-okhttp. Make sure the first four are checked. Click Finish.
+4. A number of projects should be added. Make sure that at least the following are checked: `drawee`, `fbcore`, `fresco`, `imagepipeline`, `imagepipeline-base`. The others are optional depending on your app's needs similar to the breakdown above for Gradle.
 5. Right-click (Ctrl-click on Mac) on your project and choose Properties, then click Android.
 6. Click the Add button in the bottom right, select Fresco, and click OK, then click OK again.
 

--- a/_docs/00-index.md
+++ b/_docs/00-index.md
@@ -15,7 +15,7 @@ Edit your `build.gradle` file. You must add the following line to the `dependenc
 ```groovy
 dependencies {
   // your app's other dependencies
-  compile 'com.facebook.fresco:fresco:{{site.current_version}}+'
+  compile 'com.facebook.fresco:fresco:{{site.current_version}}'
 }
 ```
 
@@ -23,18 +23,18 @@ The following optional modules may also be added, depending on the needs of your
 
 ```groovy
 dependencies {
-  // If your app supports Android versions before Ice Cream Sandwich
-  compile 'com.facebook.fresco:animated-base-support:{{site.current_version}}+'
+  // If your app supports Android versions before Ice Cream Sandwich (API level 14)
+  compile 'com.facebook.fresco:animated-base-support:{{site.current_version}}'
 
-  // For animated gif support
-  compile 'com.facebook.fresco:animated-gif:{{site.current_version}}+'
+  // For animated GIF support
+  compile 'com.facebook.fresco:animated-gif:{{site.current_version}}'
 
-  // For webp support, including animated webp
-  compile 'com.facebook.fresco:animated-webp:{{site.current_version}}+'
-  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}+'
+  // For WebP support, including animated WebP
+  compile 'com.facebook.fresco:animated-webp:{{site.current_version}}'
+  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}'
 
-  // For webp support, without animations
-  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}+'
+  // For WebP support, without animations
+  compile 'com.facebook.fresco:webpsupport:{{site.current_version}}'
 }
 ```
 

--- a/_docs/04-using-other-image-loaders.md
+++ b/_docs/04-using-other-image-loaders.md
@@ -22,7 +22,7 @@ In order to use it, the `dependencies` section of your `build.gradle` file needs
 ```groovy
 dependencies {
   // your project's other dependencies
-  compile: "com.facebook.fresco:drawee-volley:{{site.current_version}}+"
+  compile: "com.facebook.fresco:drawee-volley:{{site.current_version}}"
 }
 ```
 

--- a/_docs/04-using-other-network-layers.md
+++ b/_docs/04-using-other-network-layers.md
@@ -13,23 +13,33 @@ By default, the image pipeline uses the [HttpURLConnection](https://developer.an
 
 [OkHttp](http://square.github.io/okhttp) is a popular open-source networking library. The image pipeline has a backend that uses OkHttp instead of the Android default.
 
-#####  OkHttp in Gradle
+####  OkHttp in Gradle
 
-In order to use it, the `dependencies` section of your `build.gradle` file needs to be changed. Do **not** use the Gradle dependencies given on the [download](index.html) page. Use these instead:
+In order to use it, the `dependencies` section of your `build.gradle` file needs to be changed. Along with the Gradle dependencies given on the [download](index.html) page, add **just one** of these:
+
+For OkHttp2:
 
 ```groovy
 dependencies {
   // your project's other dependencies
-  compile "com.facebook.fresco:fresco:{{site.current_version}}+"
   compile "com.facebook.fresco:imagepipeline-okhttp:{{site.current_version}}+"
 }
 ```
 
-##### OkHttp in Eclipse
+For OkHttp3:
 
-Eclipse users should depend on **both** the `fresco` and `imagepipeline-okhttp` directories in the `frescolib` tree as described in the [Eclipse instructions](index.html#eclipse-adt).
+```groovy
+dependencies {
+  // your project's other dependencies
+  compile "com.facebook.fresco:imagepipeline-okhttp3:{{site.current_version}}+"
+}
+```
 
-##### Configuring the image pipeline with OkHttp
+#### OkHttp in Eclipse
+
+Eclipse users should depend on **either** the `imagepipeline-okhttp` and `imagepipeline-okhttp3` directories in the `frescolib` tree as described in the [Eclipse instructions](index.html#eclipse-adt).
+
+#### Configuring the image pipeline with OkHttp
 
 You must also configure the image pipeline a little differently. Instead of using `ImagePipelineConfig.newBuilder`, use `OkHttpImagePipelineConfigFactory` instead:
 
@@ -44,7 +54,7 @@ ImagePipelineConfig config = OkHttpImagePipelineConfigFactory
 Fresco.initialize(context, config);
 ```
 
-#### Handling sessions and cookies correctly
+### Handling sessions and cookies correctly
 
 The `OkHttpClient` you pass to Fresco in the above step should be set up with interceptors needed to handle authentications to your servers. See [this bug](https://github.com/facebook/fresco/issues/385) and the solutions outlined there for some problems that have occurred with cookies.
 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -257,6 +257,10 @@ section#intro {
         font-size: 110%;
       }
 
+      ol {
+        list-style: decimal outside none;
+      }
+
       .post-header {
         padding: 1em 0;
 


### PR DESCRIPTION
This updates the docs to point to the use of 0.10.0, including details of the optional modules which now exist.

I've also removed the trailing `+` signs from the dependencies as using them is not good practice.