### PR TITLE
Add resource ID based setters to GenericDraweeHierarchy and associated Builder

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -443,6 +443,16 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     setPlaceholderImage(mResources.getDrawable(resourceId));
   }
 
+  /**
+   * Sets a new placeholder drawable with scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   * @param scaleType a new scale type.
+   */
+  public void setPlaceholderImage(int resourceId, ScaleType scaleType) {
+    setPlaceholderImage(mResources.getDrawable(resourceId), scaleType);
+  }
+
   /** Sets a new failure drawable with old scale type. */
   public void setFailureImage(@Nullable Drawable drawable) {
     setChildDrawableAtIndex(mFailureImageIndex, drawable);
@@ -452,6 +462,25 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   public void setFailureImage(Drawable drawable, ScaleType scaleType) {
     setChildDrawableAtIndex(mFailureImageIndex, drawable);
     getScaleTypeDrawableAtIndex(mFailureImageIndex).setScaleType(scaleType);
+  }
+  
+  /**
+   * Sets a new failure drawable with old scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   */
+  public void setFailureImage(int resourceId) {
+    setFailureImage(mResources.getDrawable(resourceId));
+  }
+  
+  /**
+   * Sets a new failure drawable with scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   * @param scaleType a new scale type.
+   */
+  public void setFailureImage(int resourceId, ScaleType scaleType) {
+    setFailureImage(mResources.getDrawable(resourceId), scaleType);
   }
 
   /** Sets a new retry drawable with old scale type. */
@@ -464,6 +493,25 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     setChildDrawableAtIndex(mRetryImageIndex, drawable);
     getScaleTypeDrawableAtIndex(mRetryImageIndex).setScaleType(scaleType);
   }
+  
+  /**
+   * Sets a new retry drawable with old scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   */
+  public void setRetryImage(int resourceId) {
+    setRetryImage(mResources.getDrawable(resourceId));
+  }
+  
+  /**
+   * Sets a new retry drawable with scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   * @param scaleType a new scale type.
+   */
+  public void setRetryImage(int resourceId, ScaleType scaleType) {
+    setRetryImage(mResources.getDrawable(resourceId), scaleType);
+  }
 
   /** Sets a new progress bar drawable with old scale type. */
   public void setProgressBarImage(@Nullable Drawable drawable) {
@@ -474,6 +522,25 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   public void setProgressBarImage(Drawable drawable, ScaleType scaleType) {
     setChildDrawableAtIndex(mProgressBarImageIndex, drawable);
     getScaleTypeDrawableAtIndex(mProgressBarImageIndex).setScaleType(scaleType);
+  }
+  
+  /**
+   * Sets a new progress bar drawable with old scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   */
+  public void setProgressBarImage(int resourceId) {
+    setProgressBarImage(mResources.getDrawable(resourceId));
+  }
+  
+  /**
+   * Sets a new progress bar drawable with scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource.
+   * @param scaleType a new scale type.
+   */
+  public void setProgressBarImage(int resourceId, ScaleType scaleType) {
+    setProgressBarImage(mResources.getDrawable(resourceId), scaleType);
   }
 
   /** Sets the rounding params. */

--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilder.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilder.java
@@ -182,6 +182,17 @@ public class GenericDraweeHierarchyBuilder {
   }
 
   /**
+   * Sets the placeholder image.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setPlaceholderImage(int resourceId) {
+    mPlaceholderImage = mResources.getDrawable(resourceId);
+    return this;
+  }
+
+  /**
    * Gets the placeholder image.
    */
   public @Nullable Drawable getPlaceholderImage() {
@@ -225,6 +236,21 @@ public class GenericDraweeHierarchyBuilder {
   }
 
   /**
+   * Sets the placeholder image and its scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @param placeholderImageScaleType scale type for the placeholder image
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setPlaceholderImage(
+      int resourceId,
+      @Nullable ScaleType placeholderImageScaleType) {
+    mPlaceholderImage = mResources.getDrawable(resourceId);
+    mPlaceholderImageScaleType = placeholderImageScaleType;
+    return this;
+  }
+
+  /**
    * Sets the retry image.
    *
    * @param retryDrawable drawable to be used as retry image
@@ -232,6 +258,17 @@ public class GenericDraweeHierarchyBuilder {
    */
   public GenericDraweeHierarchyBuilder setRetryImage(@Nullable Drawable retryDrawable) {
     mRetryImage = retryDrawable;
+    return this;
+  }
+
+  /**
+   * Sets the retry image.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setRetryImage(int resourceId) {
+    mRetryImage = mResources.getDrawable(resourceId);
     return this;
   }
 
@@ -279,6 +316,21 @@ public class GenericDraweeHierarchyBuilder {
   }
 
   /**
+   * Sets the retry image and its scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @param retryImageScaleType scale type for the retry image
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setRetryImage(
+      int resourceId,
+      @Nullable ScaleType retryImageScaleType) {
+    mRetryImage = mResources.getDrawable(resourceId);
+    mRetryImageScaleType = retryImageScaleType;
+    return this;
+  }
+
+  /**
    * Sets the failure image.
    *
    * @param failureDrawable drawable to be used as failure image
@@ -286,6 +338,17 @@ public class GenericDraweeHierarchyBuilder {
    */
   public GenericDraweeHierarchyBuilder setFailureImage(@Nullable Drawable failureDrawable) {
     mFailureImage = failureDrawable;
+    return this;
+  }
+
+  /**
+   * Sets the failure image.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setFailureImage(int resourceId) {
+    mFailureImage = mResources.getDrawable(resourceId);
     return this;
   }
 
@@ -333,6 +396,21 @@ public class GenericDraweeHierarchyBuilder {
   }
 
   /**
+   * Sets the failure image and its scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @param failureImageScaleType scale type for the failure image
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setFailureImage(
+      int resourceId,
+      @Nullable ScaleType failureImageScaleType) {
+    mFailureImage = mResources.getDrawable(resourceId);
+    mFailureImageScaleType = failureImageScaleType;
+    return this;
+  }
+
+  /**
    * Sets the progress bar image.
    *
    * @param progressBarDrawable drawable to be used as progress bar image
@@ -340,6 +418,17 @@ public class GenericDraweeHierarchyBuilder {
    */
   public GenericDraweeHierarchyBuilder setProgressBarImage(@Nullable Drawable progressBarDrawable) {
     mProgressBarImage = progressBarDrawable;
+    return this;
+  }
+
+  /**
+   * Sets the progress bar image.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setProgressBarImage(int resourceId) {
+    mProgressBarImage = mResources.getDrawable(resourceId);
     return this;
   }
 
@@ -382,6 +471,21 @@ public class GenericDraweeHierarchyBuilder {
       Drawable progressBarDrawable,
       @Nullable ScaleType progressBarImageScaleType) {
     mProgressBarImage = progressBarDrawable;
+    mProgressBarImageScaleType = progressBarImageScaleType;
+    return this;
+  }
+
+  /**
+   * Sets the progress bar image and its scale type.
+   *
+   * @param resourceId an identifier of an Android drawable or color resource
+   * @param progressBarImageScaleType scale type for the progress bar image
+   * @return modified instance of this builder
+   */
+  public GenericDraweeHierarchyBuilder setProgressBarImage(
+      int resourceId,
+      @Nullable ScaleType progressBarImageScaleType) {
+    mProgressBarImage = mResources.getDrawable(resourceId);
     mProgressBarImageScaleType = progressBarImageScaleType;
     return this;
   }


### PR DESCRIPTION
* Add resource ID based setters for drawables in GenericDraweeHierarchy
* Add resource ID + ScaleType setters for drawables in GenericDraweeHierarchy
* Add ability to use resource IDs in GenericDraweeHierarchyBuilder (mirroring Drawable based setters)

Fixes #1178.

This was written on Github directly and not in an actual IDE, please check for any typo.