### PR TITLE
Fix shared elements transition on Lollipop

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
@@ -238,7 +238,8 @@ public class DraweeView<DH extends DraweeHierarchy> extends ImageView {
     super.onSizeChanged(w, h, oldw, oldh);
     Drawable drawable = getTopLevelDrawable();
     if (drawable != null) {
-      drawable.setBounds(0, 0, w, h);
+      drawable.setBounds(getPaddingLeft(), getPaddingTop(),
+              w - getPaddingLeft() - getPaddingRight(), h - getPaddingTop() - getPaddingBottom());
     }
   }
 

--- a/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
@@ -234,6 +234,15 @@ public class DraweeView<DH extends DraweeHierarchy> extends ImageView {
   }
 
   @Override
+  protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+    super.onSizeChanged(w, h, oldw, oldh);
+    Drawable drawable = getTopLevelDrawable();
+    if (drawable != null) {
+      drawable.setBounds(0, 0, w, h);
+    }
+  }
+
+  @Override
   public String toString() {
     return Objects.toStringHelper(this)
         .add("holder", mDraweeHolder != null ? mDraweeHolder.toString(): "<no holder set>")


### PR DESCRIPTION
Hello,
As referenced in https://github.com/facebook/fresco/issues/22, there is currently a problem for shared elements transitions that occurs on Lollipop devices but not on Marshmallow (As far as I know).

Here is the problem, illustrated by your sample app "transition":
![before](https://cloud.githubusercontent.com/assets/7100677/15249737/7ac5f9e4-1921-11e6-9e15-2a809256d9b0.gif)
I'm performing a click on the start transition button, then going back. The transition from the first to the second activity shows resize issues, and the transition back to the first activity doesn't display anything.

![after](https://cloud.githubusercontent.com/assets/7100677/15249742/7f0dc6c6-1921-11e6-952a-658d7e84dae2.gif)
With the same actions, we have the same visual result as with a device running Marshmallow.

Since ChangeBounds is animating the bounds of the the view, we need to react to the onSizeChanged callback, which is the fix I've done.
