### PR TITLE
Add support for dynamically changing backgrounds and overlays

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -578,7 +578,7 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   }
 
   /**
-   * Sets a new background image at the specified index.
+   * Sets a new overlay image at the specified index.
    *
    * This method will throw if the given index is out of bounds.
    *

--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -555,6 +555,51 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     setProgressBarImage(mResources.getDrawable(resourceId), scaleType);
   }
 
+  /**
+   * Sets a new background image at the specified index.
+   *
+   * This method will throw if the given index is out of bounds.
+   *
+   * @param drawable background image
+   */
+  public void setBackgroundImage(int index, @Nullable Drawable drawable) {
+    // Note: we do not have mNumBackgrounds to reduce the memory footprint of this class.
+    // We rely on the assumption that the first image after backgrounds is the placeholder image.
+    int numBackgrounds = mPlaceholderImageIndex;
+    Preconditions.checkArgument(
+        0 <= index && index < numBackgrounds,
+        "The given index does not correspond to a background image.");
+    setChildDrawableAtIndex(index, drawable);
+  }
+
+  /** Sets the background image if allowed. */
+  public void setBackgroundImage(@Nullable Drawable drawable) {
+    setBackgroundImage(0, drawable);
+  }
+
+  /**
+   * Sets a new background image at the specified index.
+   *
+   * This method will throw if the given index is out of bounds.
+   *
+   * @param drawable background image
+   */
+  public void setOverlayImage(int index, @Nullable Drawable drawable) {
+    // Note: we do not have mOverlaysIndex to reduce the memory footprint of this class.
+    // We rely on the assumption that the last image before overlays is the failure image.
+    int overlaysIndex = mFailureImageIndex + 1;
+    index += overlaysIndex;
+    Preconditions.checkArgument(
+        overlaysIndex <= index && index < mFadeDrawable.getNumberOfLayers(),
+        "The given index does not correspond to an overlay image.");
+    setChildDrawableAtIndex(index, drawable);
+  }
+
+  /** Sets the overlay image if allowed. */
+  public void setOverlayImage(@Nullable Drawable drawable) {
+    setOverlayImage(0, drawable);
+  }
+
   /** Sets the rounding params. */
   public void setRoundingParams(@Nullable RoundingParams roundingParams) {
     mRoundingParams = roundingParams;

--- a/samples/demo/src/main/java/com/facebook/samples/demo/MainActivity.java
+++ b/samples/demo/src/main/java/com/facebook/samples/demo/MainActivity.java
@@ -17,6 +17,7 @@ import java.util.Set;
 
 import android.app.Activity;
 import android.graphics.Bitmap;
+import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.widget.ImageView;
@@ -79,6 +80,7 @@ public class MainActivity extends Activity {
     mStaticWebpView.setImageURI(Uri.parse("https://www.gstatic.com/webp/gallery/2.sm.webp"));
 
     mAlphaWebpView.setImageURI(Uri.parse("http://frescolib.org/static/translucent.webp"));
+    mAlphaWebpView.getHierarchy().setBackgroundImage(new ColorDrawable(0xFF302013));
 
     DraweeController animatedGifController = Fresco.newDraweeControllerBuilder()
         .setAutoPlayAnimations(true)

--- a/samples/demo/src/main/res/layout/activity_main.xml
+++ b/samples/demo/src/main/res/layout/activity_main.xml
@@ -97,6 +97,8 @@
       <com.facebook.drawee.view.SimpleDraweeView
         android:id="@+id/alpha_webp"
         style="@style/drawee"
+        fresco:backgroundImage="@color/transparent"
+        fresco:overlayImage="@color/transparent"
         />
 
       <TextView

--- a/samples/demo/src/main/res/values/colors.xml
+++ b/samples/demo/src/main/res/values/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="failure">#ffff3333</color>
+    <color name="transparent">#00000000</color>
 </resources>


### PR DESCRIPTION
Summary: Allows backgrounds and overlays to be changed dynamically. Note, DraweeHierarchy space for backgrounds and overlays need to be preallocated in advance in order to be changed.

Test Plan: Verified in the sample app that:
    * setting background dynamically works
    * setting overlay dynamically works
    * setting both a background and an overlay dynamically works
    * attempting to set a backgroudn or an overlay without preallocating throws