### PR TITLE
Closed the last codeblock in 02-closeable-references.

### DIFF
--- a/_docs/02-closeable-references.md
+++ b/_docs/02-closeable-references.md
@@ -119,3 +119,4 @@ void haa(CloseableReference<?> ref) {
   });
   // caller can now safely close its copy as we made our own clone.
 }
+```


### PR DESCRIPTION
This codeblock did work on GitHub but was broken on the website,