### PR TITLE
[Fresco] Fix long press in ZoomableDraweeView

### DIFF
--- a/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableDraweeView.java
+++ b/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableDraweeView.java
@@ -274,6 +274,16 @@ public class ZoomableDraweeView extends DraweeView<GenericDraweeHierarchy> {
       FLog.v(getLogTag(), "onTouchEvent: %d, view %x, handled by the super", a, this.hashCode());
       return true;
     }
+    // None of our components reported that they handled the touch event. Upon returning false
+    // from this method, our parent won't send us any more events for this gesture. Unfortunately,
+    // some componentes may have started a delayed action, such as a long-press timer, and since we
+    // won't receive an ACTION_UP that would cancel that timer, a false event may be triggered.
+    // To prevent that we explicitly send one last cancel event when returning false.
+    MotionEvent cancelEvent = MotionEvent.obtain(event);
+    cancelEvent.setAction(MotionEvent.ACTION_CANCEL);
+    mTapGestureDetector.onTouchEvent(cancelEvent);
+    mZoomableController.onTouchEvent(cancelEvent);
+    cancelEvent.recycle();
     return false;
   }
 

--- a/samples/zoomableapp/src/main/java/com/facebook/samples/zoomableapp/MyPagerAdapter.java
+++ b/samples/zoomableapp/src/main/java/com/facebook/samples/zoomableapp/MyPagerAdapter.java
@@ -13,6 +13,9 @@
 package com.facebook.samples.zoomableapp;
 
 import android.support.v4.view.PagerAdapter;
+import android.util.Log;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -30,6 +33,7 @@ class MyPagerAdapter extends PagerAdapter {
 			.setUri("https://www.gstatic.com/webp/gallery/1.sm.jpg")
 			.build();
 		zoomableDraweeView.setController(controller);
+		zoomableDraweeView.setTapListener(createTapListener(position));
 		page.requestLayout();
 		return page;
 	}
@@ -49,7 +53,13 @@ class MyPagerAdapter extends PagerAdapter {
 	public boolean isViewFromObject(View arg0, Object arg1) {
 		return arg0 == arg1;
 	}
+
+	private GestureDetector.SimpleOnGestureListener createTapListener(final int position) {
+		return new GestureDetector.SimpleOnGestureListener() {
+			@Override
+			public void onLongPress(MotionEvent e) {
+				Log.d("MyPagerAdapter", "onLongPress: " + position);
+			}
+		};
+	}
 }
-
-
-


### PR DESCRIPTION
Tested that before this diff a false long-press would be triggered if user taps while the image is not loaded yet. Tested that this does not happen with this fix, and that long-press properly gets detected once the image gets loaded.