### PR TITLE
[Fresco] Properly handle requestDisallowInterceptTouchEvent

### DIFF
--- a/samples/zoomable/src/main/java/com/facebook/samples/zoomable/DefaultZoomableController.java
+++ b/samples/zoomable/src/main/java/com/facebook/samples/zoomable/DefaultZoomableController.java
@@ -74,6 +74,7 @@ public class DefaultZoomableController
   private final Matrix mActiveTransformInverse = new Matrix();
   private final float[] mTempValues = new float[9];
   private final RectF mTempRect = new RectF();
+  private boolean mWasTransformCorrected;
 
   public static DefaultZoomableController newInstance() {
     return new DefaultZoomableController(TransformGestureDetector.newInstance());
@@ -212,6 +213,14 @@ public class DefaultZoomableController
   @Override
   public boolean isIdentity() {
     return isMatrixIdentity(mActiveTransform, 1e-3f);
+  }
+
+  /**
+   * Returns true if the transform was corrected during the last update.
+   */
+  @Override
+  public boolean wasTransformCorrected() {
+    return mWasTransformCorrected;
   }
 
   /**
@@ -375,6 +384,7 @@ public class DefaultZoomableController
     if (transformCorrected) {
       mGestureDetector.restartGesture();
     }
+    mWasTransformCorrected = transformCorrected;
   }
 
   @Override

--- a/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableController.java
+++ b/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableController.java
@@ -71,6 +71,14 @@ public interface ZoomableController {
   boolean isIdentity();
 
   /**
+   * Returns true if the transform was corrected during the last update.
+   *
+   * This mainly happens when a gesture would cause the image to get out of limits and the
+   * transform gets corrected in order to prevent that.
+   */
+  boolean wasTransformCorrected();
+
+  /**
    * Gets the current transform.
    *
    * @return the transform

--- a/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableDraweeView.java
+++ b/samples/zoomable/src/main/java/com/facebook/samples/zoomable/ZoomableDraweeView.java
@@ -260,7 +260,7 @@ public class ZoomableDraweeView extends DraweeView<GenericDraweeHierarchy> {
       return true;
     }
     if (mZoomableController.onTouchEvent(event)) {
-      if (!mZoomableController.isIdentity()) {
+      if (!mZoomableController.wasTransformCorrected()) {
         getParent().requestDisallowInterceptTouchEvent(true);
       }
       FLog.v(


### PR DESCRIPTION
If the current gesture performed on our ZoomableDraweeView haven't caused the transform to be corrected, we request our parent to not intercept events as we are going to hndle them. If on the other hand the transform got corrected, it means we tried to scroll past the bounds and we will let our parent intercept the events in case it wants to.

As a consequence we can zoom-in, pan the image around, and once we reach the edge, the parent will take over and perform paging, as the user would expect. With this fix I hope we solved issues with ZoomableDraweeView within another scrollable containers such as ViewPager, etc.