### PR TITLE
[Fresco] Always reserve space for a background and an overlay

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -72,7 +72,7 @@ import static com.facebook.drawee.drawable.ScalingUtils.ScaleType;
  * <li> All branches except the actual image branch are optional (placeholder, failure, retry,
  * progress bar). If some branch is not specified it won't be created. Index in FadeDrawable will
  * still be reserved though.
- * <li> If overlays and/or backgrounds are specified, they are added to the same fade drawable, and
+ * <li> If overlays and/or background are specified, they are added to the same fade drawable, and
  * are always being displayed.
  * <li> ScaleType and Matrix transformations will be added only if specified. If both are
  * unspecified, then the branch for that image is attached to FadeDrawable directly. Matrix
@@ -85,6 +85,14 @@ import static com.facebook.drawee.drawable.ScalingUtils.ScaleType;
  */
 public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
 
+  private static final int BACKGROUND_IMAGE_INDEX = 0;
+  private static final int PLACEHOLDER_IMAGE_INDEX = 1;
+  private static final int ACTUAL_IMAGE_INDEX = 2;
+  private static final int PROGRESS_BAR_IMAGE_INDEX = 3;
+  private static final int RETRY_IMAGE_INDEX = 4;
+  private static final int FAILURE_IMAGE_INDEX = 5;
+  private static final int OVERLAY_IMAGES_INDEX = 6;
+
   private final Drawable mEmptyActualImageDrawable = new ColorDrawable(Color.TRANSPARENT);
 
   private final Resources mResources;
@@ -94,69 +102,50 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   private final FadeDrawable mFadeDrawable;
   private final ForwardingDrawable mActualImageWrapper;
 
-  private final int mPlaceholderImageIndex;
-  private final int mProgressBarImageIndex;
-  private final int mActualImageIndex;
-  private final int mRetryImageIndex;
-  private final int mFailureImageIndex;
-
   GenericDraweeHierarchy(GenericDraweeHierarchyBuilder builder) {
     mResources = builder.getResources();
     mRoundingParams = builder.getRoundingParams();
 
     mActualImageWrapper = new ForwardingDrawable(mEmptyActualImageDrawable);
 
-    int numBackgrounds = (builder.getBackgrounds() != null) ? builder.getBackgrounds().size() : 0;
-    int numOverlays = (builder.getOverlays() != null) ? builder.getOverlays().size() : 0;
+    int numOverlays = (builder.getOverlays() != null) ? builder.getOverlays().size() : 1;
     numOverlays += (builder.getPressedStateOverlay() != null) ? 1 : 0;
 
     // layer indices and count
-    int numLayers = 0;
-    int backgroundsIndex = numLayers;
-    numLayers += numBackgrounds;
-    mPlaceholderImageIndex = numLayers++;
-    mActualImageIndex = numLayers++;
-    mProgressBarImageIndex = numLayers++;
-    mRetryImageIndex = numLayers++;
-    mFailureImageIndex = numLayers++;
-    int overlaysIndex = numLayers;
-    numLayers += numOverlays;
+    int numLayers = OVERLAY_IMAGES_INDEX + numOverlays;
 
     // array of layers
     Drawable[] layers = new Drawable[numLayers];
-    if (numBackgrounds > 0) {
-      int index = 0;
-      for (Drawable background : builder.getBackgrounds()) {
-        layers[backgroundsIndex + index++] = buildBranch(background, null);
-      }
-    }
-    layers[mPlaceholderImageIndex] = buildBranch(
+    layers[BACKGROUND_IMAGE_INDEX] = buildBranch(builder.getBackground(), null);
+    layers[PLACEHOLDER_IMAGE_INDEX] = buildBranch(
         builder.getPlaceholderImage(),
         builder.getPlaceholderImageScaleType());
-    layers[mActualImageIndex] = buildActualImageBranch(
+    layers[ACTUAL_IMAGE_INDEX] = buildActualImageBranch(
         mActualImageWrapper,
         builder.getActualImageScaleType(),
         builder.getActualImageFocusPoint(),
         builder.getActualImageMatrix(),
         builder.getActualImageColorFilter());
-    layers[mProgressBarImageIndex] = buildBranch(
+    layers[PROGRESS_BAR_IMAGE_INDEX] = buildBranch(
         builder.getProgressBarImage(),
         builder.getProgressBarImageScaleType());
-    layers[mRetryImageIndex] = buildBranch(
+    layers[RETRY_IMAGE_INDEX] = buildBranch(
         builder.getRetryImage(),
         builder.getRetryImageScaleType());
-    layers[mFailureImageIndex] = buildBranch(
+    layers[FAILURE_IMAGE_INDEX] = buildBranch(
         builder.getFailureImage(),
         builder.getFailureImageScaleType());
     if (numOverlays > 0) {
       int index = 0;
       if (builder.getOverlays() != null) {
         for (Drawable overlay : builder.getOverlays()) {
-          layers[overlaysIndex + index++] = buildBranch(overlay, null);
+          layers[OVERLAY_IMAGES_INDEX + index++] = buildBranch(overlay, null);
         }
+      } else {
+        index = 1; // reserve space for one overlay
       }
       if (builder.getPressedStateOverlay() != null) {
-        layers[overlaysIndex + index] = buildBranch(builder.getPressedStateOverlay(), null);
+        layers[OVERLAY_IMAGES_INDEX + index] = buildBranch(builder.getPressedStateOverlay(), null);
       }
     }
 
@@ -208,18 +197,18 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
       // turn off branches (leaving backgrounds and overlays on)
       fadeOutBranches();
       // turn on placeholder
-      fadeInLayer(mPlaceholderImageIndex);
+      fadeInLayer(PLACEHOLDER_IMAGE_INDEX);
       mFadeDrawable.finishTransitionImmediately();
       mFadeDrawable.endBatchMode();
     }
   }
 
   private void fadeOutBranches() {
-    fadeOutLayer(mPlaceholderImageIndex);
-    fadeOutLayer(mActualImageIndex);
-    fadeOutLayer(mProgressBarImageIndex);
-    fadeOutLayer(mRetryImageIndex);
-    fadeOutLayer(mFailureImageIndex);
+    fadeOutLayer(PLACEHOLDER_IMAGE_INDEX);
+    fadeOutLayer(ACTUAL_IMAGE_INDEX);
+    fadeOutLayer(PROGRESS_BAR_IMAGE_INDEX);
+    fadeOutLayer(RETRY_IMAGE_INDEX);
+    fadeOutLayer(FAILURE_IMAGE_INDEX);
   }
 
   private void fadeInLayer(int index) {
@@ -235,7 +224,7 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   }
 
   private void setProgress(float progress) {
-    Drawable progressBarDrawable = getParentDrawableAtIndex(mProgressBarImageIndex).getDrawable();
+    Drawable progressBarDrawable = getParentDrawableAtIndex(PROGRESS_BAR_IMAGE_INDEX).getDrawable();
     if (progressBarDrawable == null) {
       return;
     }
@@ -245,12 +234,12 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
       if (progressBarDrawable instanceof Animatable) {
         ((Animatable) progressBarDrawable).stop();
       }
-      fadeOutLayer(mProgressBarImageIndex);
+      fadeOutLayer(PROGRESS_BAR_IMAGE_INDEX);
     } else {
       if (progressBarDrawable instanceof Animatable) {
         ((Animatable) progressBarDrawable).start();
       }
-      fadeInLayer(mProgressBarImageIndex);
+      fadeInLayer(PROGRESS_BAR_IMAGE_INDEX);
     }
     // set drawable level, scaled to [0, 10000] per drawable specification
     progressBarDrawable.setLevel(Math.round(progress * 10000));
@@ -276,7 +265,7 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     mActualImageWrapper.setDrawable(drawable);
     mFadeDrawable.beginBatchMode();
     fadeOutBranches();
-    fadeInLayer(mActualImageIndex);
+    fadeInLayer(ACTUAL_IMAGE_INDEX);
     setProgress(progress);
     if (immediate) {
       mFadeDrawable.finishTransitionImmediately();
@@ -298,10 +287,10 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   public void setFailure(Throwable throwable) {
     mFadeDrawable.beginBatchMode();
     fadeOutBranches();
-    if (mFadeDrawable.getDrawable(mFailureImageIndex) != null) {
-      fadeInLayer(mFailureImageIndex);
+    if (mFadeDrawable.getDrawable(FAILURE_IMAGE_INDEX) != null) {
+      fadeInLayer(FAILURE_IMAGE_INDEX);
     } else {
-      fadeInLayer(mPlaceholderImageIndex);
+      fadeInLayer(PLACEHOLDER_IMAGE_INDEX);
     }
     mFadeDrawable.endBatchMode();
   }
@@ -310,10 +299,10 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   public void setRetry(Throwable throwable) {
     mFadeDrawable.beginBatchMode();
     fadeOutBranches();
-    if (mFadeDrawable.getDrawable(mRetryImageIndex) != null) {
-      fadeInLayer(mRetryImageIndex);
+    if (mFadeDrawable.getDrawable(RETRY_IMAGE_INDEX) != null) {
+      fadeInLayer(RETRY_IMAGE_INDEX);
     } else {
-      fadeInLayer(mPlaceholderImageIndex);
+      fadeInLayer(PLACEHOLDER_IMAGE_INDEX);
     }
     mFadeDrawable.endBatchMode();
   }
@@ -395,20 +384,20 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
   /** Sets the actual image focus point. */
   public void setActualImageFocusPoint(PointF focusPoint) {
     Preconditions.checkNotNull(focusPoint);
-    getScaleTypeDrawableAtIndex(mActualImageIndex).setFocusPoint(focusPoint);
+    getScaleTypeDrawableAtIndex(ACTUAL_IMAGE_INDEX).setFocusPoint(focusPoint);
   }
 
   /** Sets the actual image scale type. */
   public void setActualImageScaleType(ScaleType scaleType) {
     Preconditions.checkNotNull(scaleType);
-    getScaleTypeDrawableAtIndex(mActualImageIndex).setScaleType(scaleType);
+    getScaleTypeDrawableAtIndex(ACTUAL_IMAGE_INDEX).setScaleType(scaleType);
   }
 
   public @Nullable ScaleType getActualImageScaleType() {
-    if (!hasScaleTypeDrawableAtIndex(mActualImageIndex)) {
+    if (!hasScaleTypeDrawableAtIndex(ACTUAL_IMAGE_INDEX)) {
       return null;
     }
-    return getScaleTypeDrawableAtIndex(mActualImageIndex).getScaleType();
+    return getScaleTypeDrawableAtIndex(ACTUAL_IMAGE_INDEX).getScaleType();
   }
 
   /** Sets the color filter to be applied on the actual image. */
@@ -423,13 +412,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
 
   /** Sets a new placeholder drawable with old scale type. */
   public void setPlaceholderImage(@Nullable Drawable drawable) {
-    setChildDrawableAtIndex(mPlaceholderImageIndex, drawable);
+    setChildDrawableAtIndex(PLACEHOLDER_IMAGE_INDEX, drawable);
   }
 
   /** Sets a new placeholder drawable with scale type. */
   public void setPlaceholderImage(Drawable drawable, ScaleType scaleType) {
-    setChildDrawableAtIndex(mPlaceholderImageIndex, drawable);
-    getScaleTypeDrawableAtIndex(mPlaceholderImageIndex).setScaleType(scaleType);
+    setChildDrawableAtIndex(PLACEHOLDER_IMAGE_INDEX, drawable);
+    getScaleTypeDrawableAtIndex(PLACEHOLDER_IMAGE_INDEX).setScaleType(scaleType);
 
   }
 
@@ -437,13 +426,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
    * @return true if there is a placeholder image set.
    */
   public boolean hasPlaceholderImage() {
-    return getParentDrawableAtIndex(mPlaceholderImageIndex) != null;
+    return getParentDrawableAtIndex(PLACEHOLDER_IMAGE_INDEX) != null;
   }
 
   /** Sets the placeholder image focus point. */
   public void setPlaceholderImageFocusPoint(PointF focusPoint) {
     Preconditions.checkNotNull(focusPoint);
-    getScaleTypeDrawableAtIndex(mPlaceholderImageIndex).setFocusPoint(focusPoint);
+    getScaleTypeDrawableAtIndex(PLACEHOLDER_IMAGE_INDEX).setFocusPoint(focusPoint);
   }
 
   /**
@@ -467,13 +456,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
 
   /** Sets a new failure drawable with old scale type. */
   public void setFailureImage(@Nullable Drawable drawable) {
-    setChildDrawableAtIndex(mFailureImageIndex, drawable);
+    setChildDrawableAtIndex(FAILURE_IMAGE_INDEX, drawable);
   }
 
   /** Sets a new failure drawable with scale type. */
   public void setFailureImage(Drawable drawable, ScaleType scaleType) {
-    setChildDrawableAtIndex(mFailureImageIndex, drawable);
-    getScaleTypeDrawableAtIndex(mFailureImageIndex).setScaleType(scaleType);
+    setChildDrawableAtIndex(FAILURE_IMAGE_INDEX, drawable);
+    getScaleTypeDrawableAtIndex(FAILURE_IMAGE_INDEX).setScaleType(scaleType);
   }
   
   /**
@@ -497,13 +486,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
 
   /** Sets a new retry drawable with old scale type. */
   public void setRetryImage(@Nullable Drawable drawable) {
-    setChildDrawableAtIndex(mRetryImageIndex, drawable);
+    setChildDrawableAtIndex(RETRY_IMAGE_INDEX, drawable);
   }
 
   /** Sets a new retry drawable with scale type. */
   public void setRetryImage(Drawable drawable, ScaleType scaleType) {
-    setChildDrawableAtIndex(mRetryImageIndex, drawable);
-    getScaleTypeDrawableAtIndex(mRetryImageIndex).setScaleType(scaleType);
+    setChildDrawableAtIndex(RETRY_IMAGE_INDEX, drawable);
+    getScaleTypeDrawableAtIndex(RETRY_IMAGE_INDEX).setScaleType(scaleType);
   }
   
   /**
@@ -527,13 +516,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
 
   /** Sets a new progress bar drawable with old scale type. */
   public void setProgressBarImage(@Nullable Drawable drawable) {
-    setChildDrawableAtIndex(mProgressBarImageIndex, drawable);
+    setChildDrawableAtIndex(PROGRESS_BAR_IMAGE_INDEX, drawable);
   }
 
   /** Sets a new progress bar drawable with scale type. */
   public void setProgressBarImage(Drawable drawable, ScaleType scaleType) {
-    setChildDrawableAtIndex(mProgressBarImageIndex, drawable);
-    getScaleTypeDrawableAtIndex(mProgressBarImageIndex).setScaleType(scaleType);
+    setChildDrawableAtIndex(PROGRESS_BAR_IMAGE_INDEX, drawable);
+    getScaleTypeDrawableAtIndex(PROGRESS_BAR_IMAGE_INDEX).setScaleType(scaleType);
   }
   
   /**
@@ -555,26 +544,9 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     setProgressBarImage(mResources.getDrawable(resourceId), scaleType);
   }
 
-  /**
-   * Sets a new background image at the specified index.
-   *
-   * This method will throw if the given index is out of bounds.
-   *
-   * @param drawable background image
-   */
-  public void setBackgroundImage(int index, @Nullable Drawable drawable) {
-    // Note: we do not have mNumBackgrounds to reduce the memory footprint of this class.
-    // We rely on the assumption that the first image after backgrounds is the placeholder image.
-    int numBackgrounds = mPlaceholderImageIndex;
-    Preconditions.checkArgument(
-        0 <= index && index < numBackgrounds,
-        "The given index does not correspond to a background image.");
-    setChildDrawableAtIndex(index, drawable);
-  }
-
   /** Sets the background image if allowed. */
   public void setBackgroundImage(@Nullable Drawable drawable) {
-    setBackgroundImage(0, drawable);
+    setChildDrawableAtIndex(BACKGROUND_IMAGE_INDEX, drawable);
   }
 
   /**
@@ -585,14 +557,11 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
    * @param drawable background image
    */
   public void setOverlayImage(int index, @Nullable Drawable drawable) {
-    // Note: we do not have mOverlaysIndex to reduce the memory footprint of this class.
-    // We rely on the assumption that the last image before overlays is the failure image.
-    int overlaysIndex = mFailureImageIndex + 1;
-    index += overlaysIndex;
+    // Note that overlays are by definition top-most and therefore the last elements in the array.
     Preconditions.checkArgument(
-        overlaysIndex <= index && index < mFadeDrawable.getNumberOfLayers(),
+        0 <= index && OVERLAY_IMAGES_INDEX + index < mFadeDrawable.getNumberOfLayers(),
         "The given index does not correspond to an overlay image.");
-    setChildDrawableAtIndex(index, drawable);
+    setChildDrawableAtIndex(OVERLAY_IMAGES_INDEX + index, drawable);
   }
 
   /** Sets the overlay image if allowed. */

--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilder.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilder.java
@@ -22,6 +22,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.StateListDrawable;
 
 import com.facebook.common.internal.Preconditions;
+import com.facebook.drawee.drawable.ArrayDrawable;
 
 import static com.facebook.drawee.drawable.ScalingUtils.ScaleType;
 
@@ -63,7 +64,7 @@ public class GenericDraweeHierarchyBuilder {
   private PointF mActualImageFocusPoint;
   private ColorFilter mActualImageColorFilter;
 
-  private List<Drawable> mBackgrounds;
+  private Drawable mBackground;
   private List<Drawable> mOverlays;
   private Drawable mPressedStateOverlay;
 
@@ -103,7 +104,7 @@ public class GenericDraweeHierarchyBuilder {
     mActualImageFocusPoint = null;
     mActualImageColorFilter = null;
 
-    mBackgrounds = null;
+    mBackground = null;
     mOverlays = null;
     mPressedStateOverlay = null;
 
@@ -581,34 +582,36 @@ public class GenericDraweeHierarchyBuilder {
    * Backgrounds are drawn in list order before the rest of the hierarchy and overlays. The
    * first background will be drawn at the bottom.
    *
+   * @deprecated use {@code setBackground} instead
    * @param backgrounds background drawables
    * @return modified instance of this builder
    */
+  @Deprecated
   public GenericDraweeHierarchyBuilder setBackgrounds(@Nullable List<Drawable> backgrounds) {
-    mBackgrounds = backgrounds;
-    return this;
-  }
-
-  /**
-   * Sets a single background.
-   *
-   * @param background background drawable
-   * @return modified instance of this builder
-   */
-  public GenericDraweeHierarchyBuilder setBackground(@Nullable Drawable background) {
-    if (background == null) {
-      mBackgrounds = null;
+    if (backgrounds == null) {
+      mBackground = null;
     } else {
-      mBackgrounds = Arrays.asList(background);
+      mBackground = new ArrayDrawable(backgrounds.toArray(new Drawable[backgrounds.size()]));
     }
     return this;
   }
 
   /**
-   * Gets the backgrounds.
+   * Sets a background.
+   *
+   * @param background background drawable
+   * @return modified instance of this builder
    */
-  public @Nullable List<Drawable> getBackgrounds() {
-    return mBackgrounds;
+  public GenericDraweeHierarchyBuilder setBackground(@Nullable Drawable background) {
+    mBackground = background;
+    return this;
+  }
+
+  /**
+   * Gets the background.
+   */
+  public @Nullable Drawable getBackground() {
+    return mBackground;
   }
 
   /**
@@ -694,12 +697,6 @@ public class GenericDraweeHierarchyBuilder {
     if (mOverlays != null) {
       for (Drawable overlay : mOverlays) {
         Preconditions.checkNotNull(overlay);
-      }
-    }
-
-    if (mBackgrounds != null) {
-      for (Drawable background : mBackgrounds) {
-        Preconditions.checkNotNull(background);
       }
     }
   }

--- a/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilderTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyBuilderTest.java
@@ -18,6 +18,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.StateListDrawable;
 
 import com.facebook.drawee.drawable.AndroidGraphicsTestUtils;
+import com.facebook.drawee.drawable.ArrayDrawable;
 import com.facebook.drawee.drawable.ScalingUtils;
 import org.robolectric.RobolectricTestRunner;
 
@@ -63,7 +64,7 @@ public class GenericDraweeHierarchyBuilderTest {
     assertEquals(ScaleType.CENTER_CROP, builder.getActualImageScaleType());
     assertEquals(null, builder.getActualImageMatrix());
     assertEquals(null, builder.getActualImageFocusPoint());
-    assertEquals(null, builder.getBackgrounds());
+    assertEquals(null, builder.getBackground());
     assertEquals(null, builder.getOverlays());
     assertEquals(null, builder.getRoundingParams());
   }
@@ -144,21 +145,23 @@ public class GenericDraweeHierarchyBuilderTest {
     // test backgrounds & overlays
     builder.setBackgrounds(Arrays.asList(mBackgroundDrawable1, mBackgroundDrawable2));
     builder.setOverlays(Arrays.asList(mOverlayDrawable1, mOverlayDrawable2));
-    assertArrayEquals(
-        builder.getBackgrounds().toArray(),
-        new Drawable[]{mBackgroundDrawable1, mBackgroundDrawable2});
+    assertEquals(builder.getBackground().getClass(), ArrayDrawable.class);
+    ArrayDrawable bgArrayDrawable = (ArrayDrawable) builder.getBackground();
+    assertEquals(2, bgArrayDrawable.getNumberOfLayers());
+    assertSame(mBackgroundDrawable1, bgArrayDrawable.getDrawable(0));
+    assertSame(mBackgroundDrawable2, bgArrayDrawable.getDrawable(1));
     assertArrayEquals(
         builder.getOverlays().toArray(),
         new Drawable[]{mOverlayDrawable1, mOverlayDrawable2});
     builder.setBackground(mBackgroundDrawable2);
     builder.setOverlay(mOverlayDrawable2);
     builder.setPressedStateOverlay(mPressedStateDrawable);
-    assertArrayEquals(builder.getBackgrounds().toArray(), new Drawable[]{mBackgroundDrawable2});
+    assertSame(builder.getBackground(), mBackgroundDrawable2);
     assertArrayEquals(builder.getOverlays().toArray(), new Drawable[] {mOverlayDrawable2});
     assertEquals(builder.getPressedStateOverlay().getClass(), StateListDrawable.class);
     // test clearing backgrounds & overlays
     builder.setBackground(null);
-    assertNull(builder.getBackgrounds());
+    assertNull(builder.getBackground());
     builder.setOverlay(null);
     assertNull(builder.getOverlays());
     builder.setPressedStateOverlay(null);

--- a/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyTest.java
@@ -21,6 +21,7 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.StateListDrawable;
 
 import com.facebook.drawee.drawable.AndroidGraphicsTestUtils;
+import com.facebook.drawee.drawable.ArrayDrawable;
 import com.facebook.drawee.drawable.DrawableTestUtils;
 import com.facebook.drawee.drawable.FadeDrawable;
 import com.facebook.drawee.drawable.ForwardingDrawable;
@@ -92,12 +93,14 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(5, fadeDrawable.getNumberOfLayers());
-    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
-    assertActualImageScaleType(ScaleType.FOCUS_CROP, mFocusPoint, fadeDrawable.getDrawable(1));
-    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(2));
-    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(3));
-    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER_INSIDE, fadeDrawable.getDrawable(4));
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
+    assertNull(fadeDrawable.getDrawable(0));
+    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
+    assertActualImageScaleType(ScaleType.FOCUS_CROP, mFocusPoint, fadeDrawable.getDrawable(2));
+    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(3));
+    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(4));
+    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER_INSIDE, fadeDrawable.getDrawable(5));
+    assertNull(fadeDrawable.getDrawable(6));
     verifyCallback(rootDrawable, mPlaceholderImage);
   }
 
@@ -112,12 +115,14 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(5, fadeDrawable.getNumberOfLayers());
-    assertSame(mPlaceholderImage, fadeDrawable.getDrawable(0));
-    assertSame(mProgressBarImage, fadeDrawable.getDrawable(2));
-    assertSame(mRetryImage, fadeDrawable.getDrawable(3));
-    assertSame(mFailureImage, fadeDrawable.getDrawable(4));
-    MatrixDrawable matrixDrawable = (MatrixDrawable) fadeDrawable.getDrawable(1);
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
+    assertNull(fadeDrawable.getDrawable(0));
+    assertSame(mPlaceholderImage, fadeDrawable.getDrawable(1));
+    assertSame(mProgressBarImage, fadeDrawable.getDrawable(3));
+    assertSame(mRetryImage, fadeDrawable.getDrawable(4));
+    assertSame(mFailureImage, fadeDrawable.getDrawable(5));
+    assertNull(fadeDrawable.getDrawable(6));
+    MatrixDrawable matrixDrawable = (MatrixDrawable) fadeDrawable.getDrawable(2);
     assertNotNull(matrixDrawable);
     assertEquals(mActualImageMatrix, matrixDrawable.getMatrix());
     assertSame(ForwardingDrawable.class, matrixDrawable.getCurrent().getClass());
@@ -135,12 +140,14 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(5, fadeDrawable.getNumberOfLayers());
-    assertSame(mPlaceholderImage, fadeDrawable.getDrawable(0));
-    assertSame(ForwardingDrawable.class, fadeDrawable.getDrawable(1).getClass());
-    assertSame(mProgressBarImage, fadeDrawable.getDrawable(2));
-    assertSame(mRetryImage, fadeDrawable.getDrawable(3));
-    assertSame(mFailureImage, fadeDrawable.getDrawable(4));
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
+    assertNull(fadeDrawable.getDrawable(0));
+    assertSame(mPlaceholderImage, fadeDrawable.getDrawable(1));
+    assertSame(ForwardingDrawable.class, fadeDrawable.getDrawable(2).getClass());
+    assertSame(mProgressBarImage, fadeDrawable.getDrawable(3));
+    assertSame(mRetryImage, fadeDrawable.getDrawable(4));
+    assertSame(mFailureImage, fadeDrawable.getDrawable(5));
+    assertNull(fadeDrawable.getDrawable(6));
     verifyCallback(rootDrawable, mPlaceholderImage);
   }
 
@@ -150,12 +157,14 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(5, fadeDrawable.getNumberOfLayers());
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
     assertNull(fadeDrawable.getDrawable(0));
-    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(1));
-    assertNull(fadeDrawable.getDrawable(2));
+    assertNull(fadeDrawable.getDrawable(1));
+    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(2));
     assertNull(fadeDrawable.getDrawable(3));
     assertNull(fadeDrawable.getDrawable(4));
+    assertNull(fadeDrawable.getDrawable(5));
+    assertNull(fadeDrawable.getDrawable(6));
     verifyCallback(rootDrawable, fadeDrawable);
   }
 
@@ -166,7 +175,7 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
+    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
     verifyCallback(rootDrawable, mPlaceholderImage);
   }
 
@@ -177,7 +186,7 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER, fadeDrawable.getDrawable(4));
+    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER, fadeDrawable.getDrawable(5));
     verifyCallback(rootDrawable, mFailureImage);
   }
 
@@ -188,7 +197,7 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertScaleTypeAndDrawable(mRetryImage, ScaleType.CENTER, fadeDrawable.getDrawable(3));
+    assertScaleTypeAndDrawable(mRetryImage, ScaleType.CENTER, fadeDrawable.getDrawable(4));
     verifyCallback(rootDrawable, mRetryImage);
   }
 
@@ -199,7 +208,7 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(2));
+    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(3));
     verifyCallback(rootDrawable, mProgressBarImage);
   }
 
@@ -214,12 +223,14 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(5, fadeDrawable.getNumberOfLayers());
-    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
-    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(1));
-    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(2));
-    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(3));
-    assertScaleTypeAndDrawable(mFailureImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(4));
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
+    assertNull(fadeDrawable.getDrawable(0));
+    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
+    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(2));
+    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(3));
+    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(4));
+    assertScaleTypeAndDrawable(mFailureImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(5));
+    assertNull(fadeDrawable.getDrawable(6));
     verifyCallback(rootDrawable, mPlaceholderImage);
   }
 
@@ -231,9 +242,11 @@ public class GenericDraweeHierarchyTest {
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
     assertEquals(7, fadeDrawable.getNumberOfLayers());
-    assertSame(mBackground1, fadeDrawable.getDrawable(0));
-    assertSame(mBackground2, fadeDrawable.getDrawable(1));
+    ArrayDrawable bgArrayDrawable = (ArrayDrawable) fadeDrawable.getDrawable(0);
+    assertSame(mBackground1, bgArrayDrawable.getDrawable(0));
+    assertSame(mBackground2, bgArrayDrawable.getDrawable(1));
     verifyCallback(rootDrawable, mBackground1);
+    verifyCallback(rootDrawable, mBackground2);
   }
 
   @Test
@@ -243,7 +256,7 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(6, fadeDrawable.getNumberOfLayers());
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
     assertSame(mBackground1, fadeDrawable.getDrawable(0));
     verifyCallback(rootDrawable, mBackground1);
   }
@@ -255,10 +268,11 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(7, fadeDrawable.getNumberOfLayers());
-    assertSame(mOverlay1, fadeDrawable.getDrawable(5));
-    assertSame(mOverlay2, fadeDrawable.getDrawable(6));
+    assertEquals(8, fadeDrawable.getNumberOfLayers());
+    assertSame(mOverlay1, fadeDrawable.getDrawable(6));
+    assertSame(mOverlay2, fadeDrawable.getDrawable(7));
     verifyCallback(rootDrawable, mOverlay1);
+    verifyCallback(rootDrawable, mOverlay2);
   }
 
   @Test
@@ -269,8 +283,8 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(6, fadeDrawable.getNumberOfLayers());
-    assertSame(mOverlay1, fadeDrawable.getDrawable(5));
+    assertEquals(7, fadeDrawable.getNumberOfLayers());
+    assertSame(mOverlay1, fadeDrawable.getDrawable(6));
     verifyCallback(rootDrawable, mOverlay1);
   }
 
@@ -302,16 +316,17 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(9, fadeDrawable.getNumberOfLayers());
-    assertSame(mBackground1, fadeDrawable.getDrawable(0));
-    assertSame(mBackground2, fadeDrawable.getDrawable(1));
-    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(2));
-    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(3));
-    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(4));
-    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(5));
-    assertScaleTypeAndDrawable(mFailureImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(6));
-    assertSame(mOverlay1, fadeDrawable.getDrawable(7));
-    assertSame(mOverlay2, fadeDrawable.getDrawable(8));
+    assertEquals(8, fadeDrawable.getNumberOfLayers());
+    ArrayDrawable bgArrayDrawable = (ArrayDrawable) fadeDrawable.getDrawable(0);
+    assertSame(mBackground1, bgArrayDrawable.getDrawable(0));
+    assertSame(mBackground2, bgArrayDrawable.getDrawable(1));
+    assertScaleTypeAndDrawable(mPlaceholderImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
+    assertActualImageScaleType(ScaleType.CENTER_CROP, null, fadeDrawable.getDrawable(2));
+    assertScaleTypeAndDrawable(mProgressBarImage, ScaleType.CENTER, fadeDrawable.getDrawable(3));
+    assertScaleTypeAndDrawable(mRetryImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(4));
+    assertScaleTypeAndDrawable(mFailureImage, ScaleType.FIT_CENTER, fadeDrawable.getDrawable(5));
+    assertSame(mOverlay1, fadeDrawable.getDrawable(6));
+    assertSame(mOverlay2, fadeDrawable.getDrawable(7));
     verifyCallback(rootDrawable, mBackground2);
     verifyCallback(rootDrawable, mPlaceholderImage);
     verifyCallback(rootDrawable, mOverlay2);
@@ -325,9 +340,9 @@ public class GenericDraweeHierarchyTest {
         .build();
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
-    assertEquals(7, fadeDrawable.getNumberOfLayers());
-    assertSame(mOverlay2, fadeDrawable.getDrawable(5));
-    StateListDrawable stateListDrawable = (StateListDrawable) fadeDrawable.getDrawable(6);
+    assertEquals(8, fadeDrawable.getNumberOfLayers());
+    assertSame(mOverlay2, fadeDrawable.getDrawable(6));
+    StateListDrawable stateListDrawable = (StateListDrawable) fadeDrawable.getDrawable(7);
     assertNotNull(stateListDrawable);
   }
 
@@ -359,12 +374,12 @@ public class GenericDraweeHierarchyTest {
     RootDrawable rootDrawable = (RootDrawable) dh.getTopLevelDrawable();
     FadeDrawable fadeDrawable = (FadeDrawable) rootDrawable.getCurrent();
     assertNotNull(fadeDrawable);
-    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
+    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
     Rounded roundedPlaceholder = (Rounded) mWrappedImage.getCurrent().getCurrent();
     assertRoundingParams(roundingParams, roundedPlaceholder);
-    Rounded roundedFailureImage = (Rounded) fadeDrawable.getDrawable(4).getCurrent();
+    Rounded roundedFailureImage = (Rounded) fadeDrawable.getDrawable(5).getCurrent();
     assertRoundingParams(roundingParams, roundedFailureImage);
-    Rounded roundedRetryImage = (Rounded) fadeDrawable.getDrawable(3);
+    Rounded roundedRetryImage = (Rounded) fadeDrawable.getDrawable(4);
     assertRoundingParams(roundingParams, roundedRetryImage);
     verifyCallback(rootDrawable, mWrappedImage.getCurrent().getCurrent());
     verifyCallback(rootDrawable, (Drawable) roundedFailureImage);
@@ -380,8 +395,8 @@ public class GenericDraweeHierarchyTest {
         .build();
 
     // image indexes in DH tree
-    final int placeholderImageIndex = 0;
-    final int actualImageIndex = 1;
+    final int placeholderImageIndex = 1;
+    final int actualImageIndex = 2;
 
     FadeDrawable fadeDrawable = (FadeDrawable) dh.getTopLevelDrawable().getCurrent();
 
@@ -467,15 +482,14 @@ public class GenericDraweeHierarchyTest {
 
     // image indexes in DH tree
     final int backgroundsIndex = 0;
-    final int numBackgrounds = 2;
-    final int placeholderImageIndex = numBackgrounds + 0;
-    final int actualImageIndex = numBackgrounds + 1;
-    final int progressBarImageIndex = numBackgrounds + 2;
-    final int retryImageIndex = numBackgrounds + 3;
-    final int failureImageIndex = numBackgrounds + 4;
-    final int numBranches = 5;
-    final int overlaysIndex = numBackgrounds + numBranches;
-    final int numOverlays = 2;
+    final int placeholderImageIndex = 1;
+    final int actualImageIndex = 2;
+    final int progressBarImageIndex = 3;
+    final int retryImageIndex = 4;
+    final int failureImageIndex = 5;
+    final int overlaysIndex = 6;
+    int numBackgrounds = 1; // multiple backgrounds get nested under an array drawable
+    int numOverlays = 2;
 
     FadeDrawable fadeDrawable = (FadeDrawable) dh.getTopLevelDrawable().getCurrent();
 
@@ -705,8 +719,8 @@ public class GenericDraweeHierarchyTest {
         .setFadeDuration(250)
         .build();
 
-    // image indexes in DH tree
-    final int imageIndex = 1;
+    // actual image index in DH tree
+    final int imageIndex = 2;
 
     FadeDrawable fadeDrawable = (FadeDrawable) dh.getTopLevelDrawable().getCurrent();
     ForwardingDrawable settableDrawable = (ForwardingDrawable) fadeDrawable.getDrawable(imageIndex);
@@ -773,7 +787,7 @@ public class GenericDraweeHierarchyTest {
     final GenericDraweeHierarchy dh = mBuilder
         .setPlaceholderImage(mPlaceholderImage, ScaleType.FIT_XY)
         .build();
-    testSetDrawable(dh, 0, new SetDrawableCallback() {
+    testSetDrawable(dh, 1, new SetDrawableCallback() {
       @Override
       public void setDrawable(Drawable drawable) {
         dh.setPlaceholderImage(drawable);
@@ -790,7 +804,7 @@ public class GenericDraweeHierarchyTest {
     final GenericDraweeHierarchy dh = mBuilder
         .setFailureImage(mFailureImage, null)
         .build();
-    testSetDrawable(dh, 4, new SetDrawableCallback() {
+    testSetDrawable(dh, 5, new SetDrawableCallback() {
       @Override
       public void setDrawable(Drawable drawable) {
         dh.setFailureImage(drawable);
@@ -807,7 +821,7 @@ public class GenericDraweeHierarchyTest {
     final GenericDraweeHierarchy dh = mBuilder
         .setRetryImage(mRetryImage, null)
         .build();
-    testSetDrawable(dh, 3, new SetDrawableCallback() {
+    testSetDrawable(dh, 4, new SetDrawableCallback() {
       @Override
       public void setDrawable(Drawable drawable) {
         dh.setRetryImage(drawable);
@@ -824,7 +838,7 @@ public class GenericDraweeHierarchyTest {
     final GenericDraweeHierarchy dh = mBuilder
         .setProgressBarImage(mProgressBarImage, null)
         .build();
-    testSetDrawable(dh, 2, new SetDrawableCallback() {
+    testSetDrawable(dh, 3, new SetDrawableCallback() {
       @Override
       public void setDrawable(Drawable drawable) {
         dh.setProgressBarImage(drawable);
@@ -890,8 +904,8 @@ public class GenericDraweeHierarchyTest {
         .setActualImageScaleType(ScaleType.FOCUS_CROP)
         .build();
 
-    // image indexes in DH tree
-    final int imageIndex = 1;
+    // actual image index in DH tree
+    final int imageIndex = 2;
 
     FadeDrawable fadeDrawable = (FadeDrawable) dh.getTopLevelDrawable().getCurrent();
     ScaleTypeDrawable scaleTypeDrawable = (ScaleTypeDrawable) fadeDrawable.getDrawable(imageIndex);
@@ -912,8 +926,8 @@ public class GenericDraweeHierarchyTest {
         .setPlaceholderImage(mPlaceholderImage)
         .build();
 
-    // image indexes in DH tree
-    final int imageIndex = 1;
+    // actual image index in DH tree
+    final int imageIndex = 2;
 
     FadeDrawable fadeDrawable = (FadeDrawable) dh.getTopLevelDrawable().getCurrent();
     ScaleTypeDrawable scaleTypeDrawable = (ScaleTypeDrawable) fadeDrawable.getDrawable(imageIndex);
@@ -1029,9 +1043,9 @@ public class GenericDraweeHierarchyTest {
       RootDrawable rootDrawable,
       FadeDrawable fadeDrawable) {
     assertNotNull(fadeDrawable);
-    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
-    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER, fadeDrawable.getDrawable(4));
-    assertSame(mRetryImage, fadeDrawable.getDrawable(3));
+    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
+    assertScaleTypeAndDrawable(mFailureImage, ScaleType.CENTER, fadeDrawable.getDrawable(5));
+    assertSame(mRetryImage, fadeDrawable.getDrawable(4));
     verifyCallback(rootDrawable, mWrappedLeaf);
     verifyCallback(rootDrawable, mFailureImage);
     verifyCallback(rootDrawable, mRetryImage);
@@ -1042,12 +1056,12 @@ public class GenericDraweeHierarchyTest {
       FadeDrawable fadeDrawable,
       RoundingParams roundingParams) {
     assertNotNull(fadeDrawable);
-    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(0));
+    assertScaleTypeAndDrawable(mWrappedImage, ScaleType.CENTER, fadeDrawable.getDrawable(1));
     Rounded roundedPlaceholder = (Rounded) mWrappedImage.getCurrent().getCurrent();
     assertRoundingParams(roundingParams, roundedPlaceholder);
-    Rounded roundedFailureImage = (Rounded) fadeDrawable.getDrawable(4).getCurrent();
+    Rounded roundedFailureImage = (Rounded) fadeDrawable.getDrawable(5).getCurrent();
     assertRoundingParams(roundingParams, roundedFailureImage);
-    Rounded roundedRetryImage = (Rounded) fadeDrawable.getDrawable(3);
+    Rounded roundedRetryImage = (Rounded) fadeDrawable.getDrawable(4);
     assertRoundingParams(roundingParams, roundedRetryImage);
     verifyCallback(rootDrawable, (Drawable) roundedPlaceholder);
     verifyCallback(rootDrawable, (Drawable) roundedFailureImage);

--- a/samples/demo/src/main/res/layout/activity_main.xml
+++ b/samples/demo/src/main/res/layout/activity_main.xml
@@ -110,8 +110,6 @@
       <com.facebook.drawee.view.SimpleDraweeView
         android:id="@+id/alpha_webp"
         style="@style/drawee"
-        fresco:backgroundImage="@color/transparent"
-        fresco:overlayImage="@color/transparent"
         />
 
       <TextView


### PR DESCRIPTION
This achieves two things:
* It allows us to dynamically change backgrounds and overlays
* It saves memory as we removed 5 instance integers and added only 2 instance null-references (two null elements in the array of the fade drawable)

An additional change is that multiple backgrounds are from now on deprecated. Context:
This improvement required a small interface change between GenericDraweeHierarchy and its builder. In particular, GenericDraweeHierarchy now has only one layer dedicated for a background. Multiple backgrounds are still supported via builder, but this gets emulated by wrapping them with an ArrayDrawable. In theory this should work fine, with one caveat. Rounding no longer works for multiple backgrounds. This would be relatively easy to support, but given that multiple backgrounds are rarely used feature (if ever), instead of introducing additional complexity we decided to deprecate it instead.
In case where there is only one or no background, everything should work as it was before.

Test Plan: unit tests, demo sample app
