### PR TITLE
[Fresco][RFC] Fix rounded path

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/drawable/RoundedBitmapDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/RoundedBitmapDrawable.java
@@ -23,9 +23,12 @@ import android.graphics.ColorFilter;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
+import android.graphics.Rect;
 import android.graphics.RectF;
+import android.graphics.Region;
 import android.graphics.Shader;
 import android.graphics.drawable.BitmapDrawable;
+import android.os.Build;
 
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.internal.VisibleForTesting;
@@ -283,6 +286,10 @@ public class RoundedBitmapDrawable extends BitmapDrawable
 
   private void updatePath() {
     if (mIsPathDirty) {
+      mBitmapBounds.set(0, 0, getBitmap().getWidth(), getBitmap().getHeight());
+      mTransform.mapRect(mBitmapBounds);
+      //mRootBounds.intersect(mBitmapBounds);
+
       mBorderPath.reset();
       mRootBounds.inset(mBorderWidth/2, mBorderWidth/2);
       if (mIsCircle) {
@@ -310,6 +317,13 @@ public class RoundedBitmapDrawable extends BitmapDrawable
       }
       mRootBounds.inset(-(mPadding), -(mPadding));
       mPath.setFillType(Path.FillType.WINDING);
+
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT) {
+        Path rectPath = new Path(); // TODO: preallocate
+        rectPath.addRect(mBitmapBounds, Path.Direction.CCW);
+        mPath.op(rectPath, Path.Op.INTERSECT);
+      }
+
       mIsPathDirty = false;
     }
   }

--- a/samples/round/src/main/java/com/facebook/fresco/samples/round/MainActivity.java
+++ b/samples/round/src/main/java/com/facebook/fresco/samples/round/MainActivity.java
@@ -32,7 +32,8 @@ import com.facebook.drawee.view.SimpleDraweeView;
 public class MainActivity extends Activity {
 
   private static final Uri URI = Uri.parse(
-      "http://apod.nasa.gov/apod/image/1410/20141008tleBaldridge001h990.jpg");
+      "http://cache-graphicslib.viator.com/graphicslib/3454/SITours/small-group-yosemite-tour-from-san-francisco-in-san-francisco-172092.jpg");
+      //"http://apod.nasa.gov/apod/image/1410/20141008tleBaldridge001h990.jpg");
   private static final int WIDTH = 400;
   private static final int HEIGHT = 240;
   private static final float FOCUS_X = 0.454f;
@@ -49,7 +50,6 @@ public class MainActivity extends Activity {
   static {
     SUPPORTS_BITMAP_ROUNDING = new HashSet<>();
     SUPPORTS_BITMAP_ROUNDING.add(ScaleType.CENTER_CROP);
-    SUPPORTS_BITMAP_ROUNDING.add(ScaleType.CENTER);
     SUPPORTS_BITMAP_ROUNDING.add(ScaleType.FOCUS_CROP);
   }
 
@@ -91,7 +91,7 @@ public class MainActivity extends Activity {
     builder.setRoundingParams(null);
     SimpleDraweeView unroundedImage = new SimpleDraweeView(this, builder.build());
 
-    if (SUPPORTS_BITMAP_ROUNDING.contains(scaleType)) {
+    if (true || SUPPORTS_BITMAP_ROUNDING.contains(scaleType)) {
       builder.setRoundingParams(mRoundingBitmapOnly);
     } else {
       builder.setRoundingParams(mRoundingOverlayColor);


### PR DESCRIPTION
This clips the rounded path to the actual image bounds (if smaller than view) so that we don't get repeated edges. Unfortunately, it only works on API 19.
