### PR TITLE
Samples->Comparison. Add Picasso OkHttp version 3 support

### DIFF
--- a/samples/comparison/build.gradle
+++ b/samples/comparison/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile "com.android.volley:volley:${VOLLEY_VERSION}"
     compile "com.nostra13.universalimageloader:universal-image-loader:${UIL_VERSION}"
     compile "com.squareup.picasso:picasso:${PICASSO_VERSION}"
+	compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2'
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
     compile "com.googlecode.android-query:android-query:${AQUERY_VERSION}"
     compile "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"

--- a/samples/comparison/build.gradle
+++ b/samples/comparison/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile "com.android.volley:volley:${VOLLEY_VERSION}"
     compile "com.nostra13.universalimageloader:universal-image-loader:${UIL_VERSION}"
     compile "com.squareup.picasso:picasso:${PICASSO_VERSION}"
-	compile 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2'
+    compile "com.jakewharton.picasso:picasso2-okhttp3-downloader:1.0.2"
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
     compile "com.googlecode.android-query:android-query:${AQUERY_VERSION}"
     compile "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"

--- a/samples/comparison/src/main/java/com/facebook/samples/comparison/configs/picasso/SamplePicassoFactory.java
+++ b/samples/comparison/src/main/java/com/facebook/samples/comparison/configs/picasso/SamplePicassoFactory.java
@@ -15,7 +15,7 @@ package com.facebook.samples.comparison.configs.picasso;
 import android.content.Context;
 
 import com.squareup.picasso.LruCache;
-import com.squareup.picasso.OkHttpDownloader;
+import com.jakewharton.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
 import com.facebook.samples.comparison.configs.ConfigConstants;
@@ -30,7 +30,7 @@ public class SamplePicassoFactory {
   public static Picasso getPicasso(Context context) {
     if (sPicasso == null) {
         sPicasso = new Picasso.Builder(context)
-            .downloader(new OkHttpDownloader(context, ConfigConstants.MAX_DISK_CACHE_SIZE))
+            .downloader(new OkHttp3Downloader(context, ConfigConstants.MAX_DISK_CACHE_SIZE))
             .memoryCache(new LruCache(ConfigConstants.MAX_MEMORY_CACHE_SIZE))
             .build();
     }


### PR DESCRIPTION
Current version of Picasso does not support OkHttp3, that cause runtime error.
Added temporary fix according to this: https://github.com/square/picasso/issues/1256