### PR TITLE
CircleCI: More memory for Gradle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ general:
 machine:
   environment:
     PATH: $ANDROID_NDK:$PATH
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 test:
   override:
     - ./gradlew assembleDebug -PdisablePreDex


### PR DESCRIPTION
Added GRADLE_OPTS according to https://circleci.com/docs/oom/ to give Gradle more memory, which fixes the build, see https://circleci.com/gh/oprisnik/fresco/30