### PR TITLE
Gradle: Removed nineoldandroids from animated-gif

### DIFF
--- a/animated-gif/build.gradle
+++ b/animated-gif/build.gradle
@@ -12,7 +12,6 @@ import org.apache.tools.ant.taskdefs.condition.Os
 dependencies {
     provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    compile "com.nineoldandroids:library:${NINEOLDANDROID_VERSION}"
     compile "com.android.support:support-v4:${SUPPORT_LIB_VERSION}"
     provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
     compile project(':fbcore')


### PR DESCRIPTION
The same reason as https://github.com/facebook/fresco/commit/362573b00360af2ba99d0b840ca1fb64d1dda619