### PR TITLE
handle WEBP_MUX_NO_BLEND properly in animated WebP

### DIFF
--- a/animated-base-support/src/test/java/com/facebook/imagepipeline/animated/testing/TestAnimatedDrawableSupportBackend.java
+++ b/animated-base-support/src/test/java/com/facebook/imagepipeline/animated/testing/TestAnimatedDrawableSupportBackend.java
@@ -94,7 +94,7 @@ public class TestAnimatedDrawableSupportBackend implements AnimatedDrawableBacke
         0,
         mWidth,
         mHeight,
-        false,
+        AnimatedDrawableFrameInfo.BlendOperation.NO_BLEND,
         AnimatedDrawableFrameInfo.DisposalMethod.DISPOSE_DO_NOT);
   }
 

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedDrawableFrameInfo.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedDrawableFrameInfo.java
@@ -29,12 +29,23 @@ public class AnimatedDrawableFrameInfo {
     DISPOSE_TO_PREVIOUS
   }
 
+  /**
+   * Indicates how transparent pixels of the current frame are blended
+   * with those of the previous canvas.
+   */
+  public enum BlendOperation {
+    /** Blend **/
+    BLEND_WITH_PREVIOUS,
+    /** Do not blend **/
+    NO_BLEND,
+  }
+
   public final int frameNumber;
   public final int xOffset;
   public final int yOffset;
   public final int width;
   public final int height;
-  public final boolean shouldBlendWithPreviousFrame;
+  public final BlendOperation blendOperation;
   public final DisposalMethod disposalMethod;
 
   public AnimatedDrawableFrameInfo(
@@ -43,14 +54,14 @@ public class AnimatedDrawableFrameInfo {
       int yOffset,
       int width,
       int height,
-      boolean shouldBlendWithPreviousFrame,
+      BlendOperation blendOperation,
       DisposalMethod disposalMethod) {
     this.frameNumber = frameNumber;
     this.xOffset = xOffset;
     this.yOffset = yOffset;
     this.width = width;
     this.height = height;
-    this.shouldBlendWithPreviousFrame = shouldBlendWithPreviousFrame;
+    this.blendOperation = blendOperation;
     this.disposalMethod = disposalMethod;
   }
 }

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedImageCompositor.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedImageCompositor.java
@@ -19,6 +19,7 @@ import android.graphics.PorterDuffXfermode;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableBackend;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo;
+import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo.BlendOperation;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo.DisposalMethod;
 import com.facebook.imagepipeline.animated.base.AnimatedImage;
 
@@ -86,8 +87,7 @@ public class AnimatedImageCompositor {
 
     // If blending is required, prepare the canvas with the nearest cached frame.
     int nextIndex;
-    AnimatedDrawableFrameInfo frameInfo = mAnimatedDrawableBackend.getFrameInfo(frameNumber);
-    if (frameInfo.shouldBlendWithPreviousFrame && frameNumber > 0) {
+    if (!isKeyFrame(frameNumber)) {
       // Blending is required. nextIndex points to the next index to render onto the canvas.
       nextIndex = prepareCanvasWithClosestCachedFrame(frameNumber - 1, canvas);
     } else {
@@ -98,10 +98,13 @@ public class AnimatedImageCompositor {
     // Iterate from nextIndex to the frame number just preceding the one we're trying to render
     // and composite them in order according to the Disposal Method.
     for (int index = nextIndex; index < frameNumber; index++) {
-      frameInfo = mAnimatedDrawableBackend.getFrameInfo(index);
+      AnimatedDrawableFrameInfo frameInfo = mAnimatedDrawableBackend.getFrameInfo(index);
       DisposalMethod disposalMethod = frameInfo.disposalMethod;
       if (disposalMethod == DisposalMethod.DISPOSE_TO_PREVIOUS) {
         continue;
+      }
+      if (frameInfo.blendOperation == BlendOperation.NO_BLEND) {
+        disposeToBackground(canvas, frameInfo);
       }
       mAnimatedDrawableBackend.renderFrame(index, canvas);
       mCallback.onIntermediateResult(index, bitmap);
@@ -110,6 +113,10 @@ public class AnimatedImageCompositor {
       }
     }
 
+    AnimatedDrawableFrameInfo frameInfo = mAnimatedDrawableBackend.getFrameInfo(frameNumber);
+    if (frameInfo.blendOperation == BlendOperation.NO_BLEND) {
+      disposeToBackground(canvas, frameInfo);
+    }
     // Finally, we render the current frame. We don't dispose it.
     mAnimatedDrawableBackend.renderFrame(frameNumber, canvas);
   }
@@ -159,7 +166,7 @@ public class AnimatedImageCompositor {
               startBitmap.close();
             }
           } else {
-            if (!frameInfo.shouldBlendWithPreviousFrame) {
+            if (isKeyFrame(index)) {
               return index;
             } else {
               // Keep going.
@@ -201,10 +208,7 @@ public class AnimatedImageCompositor {
       // Need this frame so keep going.
       return FrameNeededResult.REQUIRED;
     } else if (disposalMethod == DisposalMethod.DISPOSE_TO_BACKGROUND) {
-      if (frameInfo.xOffset == 0 &&
-          frameInfo.yOffset == 0 &&
-          frameInfo.width == mAnimatedDrawableBackend.getRenderedWidth() &&
-          frameInfo.height == mAnimatedDrawableBackend.getRenderedHeight()) {
+      if (isFullFrame(frameInfo)) {
         // The frame covered the whole image and we're disposing to background,
         // so we don't even need to draw this frame.
         return FrameNeededResult.NOT_REQUIRED;
@@ -218,5 +222,24 @@ public class AnimatedImageCompositor {
     } else {
       return FrameNeededResult.ABORT;
     }
+  }
+
+  private boolean isKeyFrame(int index) {
+    if (index == 0) {
+      return true;
+    }
+    AnimatedDrawableFrameInfo currFrameInfo = mAnimatedDrawableBackend.getFrameInfo(index);
+    AnimatedDrawableFrameInfo prevFrameInfo = mAnimatedDrawableBackend.getFrameInfo(index - 1);
+    if (currFrameInfo.blendOperation == BlendOperation.NO_BLEND && isFullFrame(currFrameInfo)) {
+      return true;
+    } else
+      return prevFrameInfo.disposalMethod == DisposalMethod.DISPOSE_TO_BACKGROUND && isFullFrame(prevFrameInfo);
+  }
+
+  private boolean isFullFrame(AnimatedDrawableFrameInfo frameInfo) {
+    return frameInfo.xOffset == 0 &&
+            frameInfo.yOffset == 0 &&
+            frameInfo.width == mAnimatedDrawableBackend.getRenderedWidth() &&
+            frameInfo.height == mAnimatedDrawableBackend.getRenderedHeight();
   }
 }

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedImageCompositor.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedImageCompositor.java
@@ -97,8 +97,9 @@ public class AnimatedImageCompositor {
 
     // Iterate from nextIndex to the frame number just preceding the one we're trying to render
     // and composite them in order according to the Disposal Method.
+    AnimatedDrawableFrameInfo frameInfo;
     for (int index = nextIndex; index < frameNumber; index++) {
-      AnimatedDrawableFrameInfo frameInfo = mAnimatedDrawableBackend.getFrameInfo(index);
+      frameInfo = mAnimatedDrawableBackend.getFrameInfo(index);
       DisposalMethod disposalMethod = frameInfo.disposalMethod;
       if (disposalMethod == DisposalMethod.DISPOSE_TO_PREVIOUS) {
         continue;
@@ -113,7 +114,7 @@ public class AnimatedImageCompositor {
       }
     }
 
-    AnimatedDrawableFrameInfo frameInfo = mAnimatedDrawableBackend.getFrameInfo(frameNumber);
+    frameInfo = mAnimatedDrawableBackend.getFrameInfo(frameNumber);
     if (frameInfo.blendOperation == BlendOperation.NO_BLEND) {
       disposeToBackground(canvas, frameInfo);
     }

--- a/animated-base/src/test/java/com/facebook/imagepipeline/animated/testing/TestAnimatedDrawableBackend.java
+++ b/animated-base/src/test/java/com/facebook/imagepipeline/animated/testing/TestAnimatedDrawableBackend.java
@@ -94,7 +94,7 @@ public class TestAnimatedDrawableBackend implements AnimatedDrawableBackend {
         0,
         mWidth,
         mHeight,
-        false,
+        AnimatedDrawableFrameInfo.BlendOperation.NO_BLEND,
         AnimatedDrawableFrameInfo.DisposalMethod.DISPOSE_DO_NOT);
   }
 

--- a/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
+++ b/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
@@ -17,6 +17,7 @@ import com.facebook.common.internal.DoNotStrip;
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.soloader.SoLoaderShim;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo;
+import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo.BlendOperation;
 import com.facebook.imagepipeline.animated.base.AnimatedImage;
 import com.facebook.imagepipeline.animated.factory.AnimatedImageDecoder;
 
@@ -150,7 +151,7 @@ public class GifImage implements AnimatedImage, AnimatedImageDecoder {
           frame.getYOffset(),
           frame.getWidth(),
           frame.getHeight(),
-          true,
+          BlendOperation.BLEND_WITH_PREVIOUS,
           fromGifDisposalMethod(frame.getDisposalMode()));
     } finally {
       frame.dispose();

--- a/animated-webp/src/main/java/com/facebook/animated/webp/WebPFrame.java
+++ b/animated-webp/src/main/java/com/facebook/animated/webp/WebPFrame.java
@@ -81,8 +81,8 @@ public class WebPFrame implements AnimatedImageFrame {
     return nativeShouldDisposeToBackgroundColor();
   }
 
-  public boolean shouldBlendWithPreviousFrame() {
-    return nativeShouldBlendWithPreviousFrame();
+  public boolean isBlendWithPreviousFrame() {
+    return nativeIsBlendWithPreviousFrame();
   }
 
   private native void nativeRenderFrame(int width, int height, Bitmap bitmap);
@@ -92,7 +92,7 @@ public class WebPFrame implements AnimatedImageFrame {
   private native int nativeGetXOffset();
   private native int nativeGetYOffset();
   private native boolean nativeShouldDisposeToBackgroundColor();
-  private native boolean nativeShouldBlendWithPreviousFrame();
+  private native boolean nativeIsBlendWithPreviousFrame();
   private native void nativeDispose();
   private native void nativeFinalize();
 }

--- a/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
+++ b/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
@@ -17,6 +17,7 @@ import com.facebook.common.internal.DoNotStrip;
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.soloader.SoLoaderShim;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo;
+import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo.BlendOperation;
 import com.facebook.imagepipeline.animated.base.AnimatedDrawableFrameInfo.DisposalMethod;
 import com.facebook.imagepipeline.animated.base.AnimatedImage;
 import com.facebook.imagepipeline.animated.factory.AnimatedImageDecoder;
@@ -156,7 +157,9 @@ public class WebPImage implements AnimatedImage, AnimatedImageDecoder {
           frame.getYOffset(),
           frame.getWidth(),
           frame.getHeight(),
-          frame.shouldBlendWithPreviousFrame(),
+          frame.isBlendWithPreviousFrame() ?
+              BlendOperation.BLEND_WITH_PREVIOUS :
+              BlendOperation.NO_BLEND,
           frame.shouldDisposeToBackgroundColor() ?
               DisposalMethod.DISPOSE_TO_BACKGROUND :
               DisposalMethod.DISPOSE_DO_NOT);

--- a/animated-webp/src/main/jni/webpimage/webp.cpp
+++ b/animated-webp/src/main/jni/webpimage/webp.cpp
@@ -750,7 +750,7 @@ jboolean WebPFrame_nativeShouldDisposeToBackgroundColor(JNIEnv* pEnv, jobject th
  *
  * @return whether the current frame should be alpha blended over the previous frame
  */
-jboolean WebPFrame_nativeShouldBlendWithPreviousFrame(JNIEnv* pEnv, jobject thiz) {
+jboolean WebPFrame_nativeIsBlendWithPreviousFrame(JNIEnv* pEnv, jobject thiz) {
   auto spNativeContext = getWebPFrameNativeContext(pEnv, thiz);
   if (!spNativeContext) {
     throwIllegalStateException(pEnv, "Already disposed");
@@ -847,9 +847,9 @@ static JNINativeMethod sWebPFrameMethods[] = {
   { "nativeShouldDisposeToBackgroundColor",
     "()Z",
     (void*)WebPFrame_nativeShouldDisposeToBackgroundColor },
-  { "nativeShouldBlendWithPreviousFrame",
+  { "nativeIsBlendWithPreviousFrame",
     "()Z",
-    (void*)WebPFrame_nativeShouldBlendWithPreviousFrame },
+    (void*)WebPFrame_nativeIsBlendWithPreviousFrame },
   { "nativeDispose",
     "()V",
     (void*)WebPFrame_nativeDispose },

--- a/samples/animation/src/main/java/com/facebook/samples/animation/MainActivity.java
+++ b/samples/animation/src/main/java/com/facebook/samples/animation/MainActivity.java
@@ -104,7 +104,7 @@ public class MainActivity extends Activity {
     final ToggleButton webpToggle = (ToggleButton) findViewById(R.id.toggle_webp);
     webpToggle.setEnabled(false);
     mAnimatedWebpView = (SimpleDraweeView) findViewById(R.id.animated_webp);
-    Uri animatedWebpUri = Uri.parse("http://www.gstatic.com/webp/animated/1.webp");
+    Uri animatedWebpUri = Uri.parse("https://dl.dropboxusercontent.com/u/11995554/11_21.webp");
     DraweeController webpController = Fresco.newDraweeControllerBuilder()
         .setUri(animatedWebpUri)
         .setControllerListener(new BaseControllerListener<ImageInfo>() {


### PR DESCRIPTION
There are some problem to process animated WebP images with NO_BLEND, sub frame.

This is the video of the problem.
https://dl.dropboxusercontent.com/u/11995554/2016_07_12_21_30_54.mp4

And this is the webp image of the problem.
https://dl.dropboxusercontent.com/u/11995554/11_21.webp

`WEBP_MUX_NO_BLEND` means that you do not need previous pixels of current frame region. But fresco ignores whole previous frame.

This is animation decoding logic in WebP repo.
https://github.com/webmproject/libwebp/blob/master/src/demux/anim_decode.c#L305