### PR TITLE
Added support for synchronous small disk cache check

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -454,10 +454,13 @@ public class ImagePipeline {
     final CacheKey cacheKey = mCacheKeyFactory.getEncodedCacheKey(imageRequest, null);
     final ImageRequest.CacheChoice cacheChoice = imageRequest.getCacheChoice();
 
-    if (cacheChoice == ImageRequest.CacheChoice.SMALL) {
-      return mSmallImageBufferedDiskCache.diskCheckSync(cacheKey);
-    } else {
-      return mMainBufferedDiskCache.diskCheckSync(cacheKey);
+    switch (cacheChoice) {
+      case DEFAULT:
+        return mMainBufferedDiskCache.diskCheckSync(cacheKey);
+      case SMALL:
+        return mSmallImageBufferedDiskCache.diskCheckSync(cacheKey);
+      default:
+        return false;
     }
   }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -44,7 +44,6 @@ import com.facebook.imagepipeline.request.ImageRequestBuilder;
 
 import bolts.Continuation;
 import bolts.Task;
-
 import com.android.internal.util.Predicate;
 
 /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -423,7 +423,8 @@ public class ImagePipeline {
    * @return true if the image was found in the disk cache, false otherwise.
    */
   public boolean isInDiskCacheSync(final Uri uri) {
-    return isInDiskCacheSync(uri, ImageRequest.CacheChoice.DEFAULT);
+    return isInDiskCacheSync(uri, ImageRequest.CacheChoice.SMALL) ||
+            isInDiskCacheSync(uri, ImageRequest.CacheChoice.DEFAULT);
   }
 
   /**

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ImagePipelineTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ImagePipelineTest.java
@@ -387,6 +387,20 @@ public class ImagePipelineTest {
   }
 
   @Test
+  public void testIsInDiskCacheFromMainDiskCache() {
+    when(mImageRequest.getCacheChoice()).thenReturn(ImageRequest.CacheChoice.DEFAULT);
+    when(mMainDiskStorageCache.diskCheckSync(any(CacheKey.class))).thenReturn(true);
+    assertTrue(mImagePipeline.isInDiskCacheSync(mImageRequest));
+  }
+
+  @Test
+  public void testIsInDiskCacheFromSmallDiskCache() {
+    when(mImageRequest.getCacheChoice()).thenReturn(ImageRequest.CacheChoice.SMALL);
+    when(mSmallImageDiskStorageCache.diskCheckSync(any(CacheKey.class))).thenReturn(true);
+    assertTrue(mImagePipeline.isInDiskCacheSync(mImageRequest));
+  }
+
+  @Test
   public void testClearDiskCaches() {
     mImagePipeline.clearDiskCaches();
     verify(mMainDiskStorageCache).clearAll();


### PR DESCRIPTION
Added a support to check in small disk cache synchronously.
Without this change, there is no way to check cache in small disk cache.
So I added this support.