### PR TITLE
Reduce Lock contentions in AnimatedDrawableBackends

### DIFF
--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableCachingBackendImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableCachingBackendImpl.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import android.app.ActivityManager;
@@ -326,18 +325,6 @@ public class AnimatedDrawableCachingBackendImpl extends DelegatingAnimatedDrawab
   private CloseableReference<Bitmap> obtainBitmapInternal() {
     Bitmap bitmap;
     synchronized (this) {
-      long nowNanos = System.nanoTime();
-      long waitUntilNanos = nowNanos + TimeUnit.NANOSECONDS.convert(20, TimeUnit.MILLISECONDS);
-      while (mFreeBitmaps.isEmpty() && nowNanos < waitUntilNanos) {
-        try {
-          TimeUnit.NANOSECONDS.timedWait(this, waitUntilNanos - nowNanos);
-          nowNanos = System.nanoTime();
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException(e);
-        }
-      }
-
       if (mFreeBitmaps.isEmpty()) {
         bitmap = createNewBitmap();
       } else {


### PR DESCRIPTION
There are lock contentions in AnimatedDrawableBackendImpl, AnimatedDrawableCachingBackendImpl.

I guess these locks prevent creating temporary bitmaps unnecessarily. But mostly render operations' scheduling is serial schedule by DefaultSerialExecutorService. So that implementation is not required.

This video is recoded using fresco v0.12.0.
https://www.dropbox.com/s/wwrl8fd2mjeiqs0/2016_08_02_23_46_54.mp4?dl=0

This video is recoded using patched version.
https://www.dropbox.com/s/5bmlatb4zh2aaaw/2016_08_02_23_51_36.mp4?dl=0
