### PR TITLE
Use initial capaticy constructor when it's appropriate

### DIFF
--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
@@ -179,10 +179,11 @@ public class AnimatedImageFactoryImpl implements AnimatedImageFactory {
   private List<CloseableReference<Bitmap>> decodeAllFrames(
       AnimatedImage image,
       Bitmap.Config bitmapConfig) {
-    final List<CloseableReference<Bitmap>> bitmaps = new ArrayList<>();
     AnimatedImageResult tempResult = AnimatedImageResult.forAnimatedImage(image);
     AnimatedDrawableBackend drawableBackend =
         mAnimatedDrawableBackendProvider.get(tempResult, null);
+    final List<CloseableReference<Bitmap>> bitmaps = new ArrayList<>(
+        drawableBackend.getFrameCount());
     AnimatedImageCompositor animatedImageCompositor = new AnimatedImageCompositor(
         drawableBackend,
         new AnimatedImageCompositor.Callback() {

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableCachingBackendImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableCachingBackendImpl.java
@@ -547,7 +547,7 @@ public class AnimatedDrawableCachingBackendImpl extends DelegatingAnimatedDrawab
 
   @VisibleForTesting
   synchronized Set<Integer> getFramesCached() {
-    Set<Integer> set = new HashSet<Integer>();
+    Set<Integer> set = new HashSet<Integer>(mCachedBitmaps.size());
     for (int i = 0; i < mCachedBitmaps.size(); i++) {
       set.add(mCachedBitmaps.keyAt(i));
     }

--- a/animated-base/src/main/java/com/facebook/imagepipeline/image/CloseableAnimatedBitmap.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/image/CloseableAnimatedBitmap.java
@@ -41,8 +41,8 @@ public class CloseableAnimatedBitmap extends CloseableBitmap {
       List<Integer> durations) {
     Preconditions.checkNotNull(bitmapReferences);
     Preconditions.checkState(bitmapReferences.size() >= 1, "Need at least 1 frame!");
-    mBitmapReferences = new ArrayList<>();
-    mBitmaps = new ArrayList<>();
+    mBitmapReferences = new ArrayList<>(bitmapReferences.size());
+    mBitmaps = new ArrayList<>(bitmapReferences.size());
     for (CloseableReference<Bitmap> bitmapReference : bitmapReferences) {
       mBitmapReferences.add(bitmapReference.clone());
       mBitmaps.add(bitmapReference.get());
@@ -64,8 +64,8 @@ public class CloseableAnimatedBitmap extends CloseableBitmap {
       ResourceReleaser<Bitmap> resourceReleaser) {
     Preconditions.checkNotNull(bitmaps);
     Preconditions.checkState(bitmaps.size() >= 1, "Need at least 1 frame!");
-    mBitmaps = new ArrayList<>();
-    mBitmapReferences = new ArrayList<>();
+    mBitmaps = new ArrayList<>(bitmaps.size());
+    mBitmapReferences = new ArrayList<>(bitmaps.size());
     for (Bitmap bitmap : bitmaps) {
       mBitmapReferences.add(CloseableReference.of(bitmap, resourceReleaser));
       mBitmaps.add(bitmap);

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/cache/CountingLruMap.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/cache/CountingLruMap.java
@@ -66,7 +66,7 @@ public class CountingLruMap<K, V> {
   /** Gets the all matching elements. */
   public synchronized ArrayList<LinkedHashMap.Entry<K, V>> getMatchingEntries(
       @Nullable Predicate<K> predicate) {
-    ArrayList<LinkedHashMap.Entry<K, V>> matchingEntries = new ArrayList<>();
+    ArrayList<LinkedHashMap.Entry<K, V>> matchingEntries = new ArrayList<>(mMap.entrySet().size());
     for (LinkedHashMap.Entry<K, V> entry : mMap.entrySet()) {
       if (predicate == null || predicate.apply(entry.getKey())) {
         matchingEntries.add(entry);

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
@@ -132,7 +132,7 @@ public class BitmapCounter {
           throw new TooManyBitmapsException();
         }
       }
-      List<CloseableReference<Bitmap>> ret = new ArrayList<>();
+      List<CloseableReference<Bitmap>> ret = new ArrayList<>(bitmaps.size());
       for (Bitmap bitmap : bitmaps) {
         ret.add(CloseableReference.of(bitmap, mUnpooledBitmapsReleaser));
       }


### PR DESCRIPTION
When you create a <code>ArrayList</code> or <code>HashSet</code>, you have to use constructor with
initial capacity argument if you know its final size beforehand.
Because we can avoid enlarging its backing array. This becomes critical
when the size of list becomes larger. For example, the <code>mBitmaps</code>
field in <code>CloseableAnimatedBitmap</code> class can hold many bitmaps, because
it holds bitmaps of animation.

Many classes in this project already follow such usage. I found
some classes that do not follow it, and changed those.