### PR TITLE
Configure max bitmap size, roundup fraction by ResizeOptions

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ResizeOptions.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ResizeOptions.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.util.HashCodeUtil;
+import com.facebook.imageutils.BitmapUtil;
 
 /**
  * Options for resizing.
@@ -22,19 +23,44 @@ import com.facebook.common.util.HashCodeUtil;
  */
 public class ResizeOptions {
 
+  public static final float DEFAULT_ROUNDUP_FRACTION = 2.0f/3;
+
   /* target width (in pixels) */
   public final int width;
 
   /* target height (in pixels) */
   public final int height;
 
+  /* max supported bitmap size (in pixels), defaults to BitmapUtil.MAX_BITMAP_SIZE */
+  public final float maxBitmapSize;
+
+  /* round-up fraction for resize process, defaults to DEFAULT_ROUNDUP_FRACTION */
+  public final float roundUpFraction;
+
   public ResizeOptions(
       int width,
       int height) {
+    this(width, height, BitmapUtil.MAX_BITMAP_SIZE);
+  }
+
+  public ResizeOptions(
+      int width,
+      int height,
+      float maxBitmapSize) {
+    this(width, height, maxBitmapSize, DEFAULT_ROUNDUP_FRACTION);
+  }
+
+  public ResizeOptions(
+      int width,
+      int height,
+      float maxBitmapSize,
+      float roundUpFraction) {
     Preconditions.checkArgument(width > 0);
     Preconditions.checkArgument(height > 0);
     this.width = width;
     this.height = height;
+    this.maxBitmapSize = maxBitmapSize;
+    this.roundUpFraction = roundUpFraction;
   }
 
   @Override

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -243,11 +243,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
     return ratio;
   }
 
-  @VisibleForTesting static int roundNumerator(float maxRatio) {
-    return roundNumerator(maxRatio, ResizeOptions.DEFAULT_ROUNDUP_FRACTION);
-  }
-
-  static int roundNumerator(float maxRatio, float roundUpFraction) {
+  @VisibleForTesting static int roundNumerator(float maxRatio, float roundUpFraction) {
     return (int) (roundUpFraction + maxRatio * JpegTranscoder.SCALE_DENOMINATOR);
   }
 

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
@@ -297,12 +297,18 @@ public class ResizeAndRotateProducerTest {
 
   @Test
   public void testRoundNumerator() {
-    assertEquals(1, ResizeAndRotateProducer.roundNumerator(1.0f/8));
-    assertEquals(1, ResizeAndRotateProducer.roundNumerator(5.0f/32));
-    assertEquals(1, ResizeAndRotateProducer.roundNumerator(1.0f/6 - 0.01f));
-    assertEquals(2, ResizeAndRotateProducer.roundNumerator(1.0f/6));
-    assertEquals(2, ResizeAndRotateProducer.roundNumerator(3.0f/16));
-    assertEquals(2, ResizeAndRotateProducer.roundNumerator(2.0f/8));
+    assertEquals(1, ResizeAndRotateProducer.roundNumerator(
+        1.0f/8, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
+    assertEquals(1, ResizeAndRotateProducer.roundNumerator(
+        5.0f/32, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
+    assertEquals(1, ResizeAndRotateProducer.roundNumerator(
+        1.0f/6 - 0.01f, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
+    assertEquals(2, ResizeAndRotateProducer.roundNumerator(
+        1.0f/6, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
+    assertEquals(2, ResizeAndRotateProducer.roundNumerator(
+        3.0f/16, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
+    assertEquals(2, ResizeAndRotateProducer.roundNumerator(
+        2.0f/8, ResizeOptions.DEFAULT_ROUNDUP_FRACTION));
   }
 
   @Test


### PR DESCRIPTION
Added `maxBitmapSize`, `roundUpFraction` to `ResizeOptions`, making these options can be configurable by user.

See also: #840