### PR TITLE
Fix creation of synthetic methods

### DIFF
--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DraweeConfig.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DraweeConfig.java
@@ -23,7 +23,7 @@ public class DraweeConfig {
   @Nullable
   private final ImmutableList<DrawableFactory> mCustomDrawableFactories;
 
-  private DraweeConfig(Builder builder) {
+  /* PACKAGE */ DraweeConfig(Builder builder) {
     mCustomDrawableFactories = builder.mCustomDrawableFactories != null
         ? ImmutableList.copyOf(builder.mCustomDrawableFactories)
         : null;
@@ -40,7 +40,7 @@ public class DraweeConfig {
 
   public static class Builder {
 
-    private List<DrawableFactory> mCustomDrawableFactories;
+    /* PACKAGE */ List<DrawableFactory> mCustomDrawableFactories;
 
     /**
      * Add a custom drawable factory that will be used to create

--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
@@ -48,8 +48,8 @@ public class PipelineDraweeController
   private static final Class<?> TAG = PipelineDraweeController.class;
 
   // Components
-  private final Resources mResources;
-  private final AnimatedDrawableFactory mAnimatedDrawableFactory;
+  /* PACKAGE */ final Resources mResources;
+  /* PACKAGE */ final AnimatedDrawableFactory mAnimatedDrawableFactory;
   @Nullable
   private final ImmutableList<DrawableFactory> mDrawableFactories;
 

--- a/drawee/src/main/java/com/facebook/drawee/components/DeferredReleaser.java
+++ b/drawee/src/main/java/com/facebook/drawee/components/DeferredReleaser.java
@@ -47,7 +47,7 @@ public class DeferredReleaser {
     public void release();
   }
 
-  private final Set<Releasable> mPendingReleasables;
+  /* PACKAGE */ final Set<Releasable> mPendingReleasables;
   private final Handler mUiHandler;
 
   public DeferredReleaser() {
@@ -99,7 +99,7 @@ public class DeferredReleaser {
     mPendingReleasables.remove(releasable);
   }
 
-  private static void ensureOnUiThread() {
+  /* PACKAGE */ static void ensureOnUiThread() {
     Preconditions.checkState(Looper.getMainLooper().getThread() == Thread.currentThread());
   }
 }

--- a/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
@@ -485,7 +485,7 @@ public abstract class AbstractDraweeController<T, INFO> implements
     mDataSource.subscribe(dataSubscriber, mUiThreadImmediateExecutor);
   }
 
-  private void onNewResultInternal(
+  /* PACKAGE */ void onNewResultInternal(
       String id,
       DataSource<T> dataSource,
       @Nullable T image,
@@ -540,7 +540,7 @@ public abstract class AbstractDraweeController<T, INFO> implements
     }
   }
 
-  private void onFailureInternal(
+  /* PACKAGE */ void onFailureInternal(
       String id,
       DataSource<T> dataSource,
       Throwable throwable,
@@ -575,7 +575,7 @@ public abstract class AbstractDraweeController<T, INFO> implements
     }
   }
 
-  private void onProgressUpdateInternal(
+  /* PACKAGE */ void onProgressUpdateInternal(
       String id,
       DataSource<T> dataSource,
       float progress,

--- a/drawee/src/main/java/com/facebook/drawee/view/DraweeTransition.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/DraweeTransition.java
@@ -35,7 +35,7 @@ public class DraweeTransition extends Transition {
   private static final String PROPNAME_BOUNDS = "draweeTransition:bounds";
 
   private final ScalingUtils.ScaleType mFromScale;
-  private final ScalingUtils.ScaleType mToScale;
+  /* PACKAGE */ final ScalingUtils.ScaleType mToScale;
 
   public static TransitionSet createTransitionSet(
       ScalingUtils.ScaleType fromScale,

--- a/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
@@ -51,7 +51,7 @@ public class OkHttpNetworkFetcher extends
     }
   }
 
-  private static final String TAG = "OkHttpNetworkFetchProducer";
+  /* PACKAGE */ static final String TAG = "OkHttpNetworkFetchProducer";
   private static final String QUEUE_TIME = "queue_time";
   private static final String FETCH_TIME = "fetch_time";
   private static final String TOTAL_TIME = "total_time";
@@ -59,7 +59,7 @@ public class OkHttpNetworkFetcher extends
 
   private final OkHttpClient mOkHttpClient;
 
-  private Executor mCancellationExecutor;
+  /* PACKAGE */ Executor mCancellationExecutor;
 
   /**
    * @param okHttpClient client to use
@@ -172,7 +172,7 @@ public class OkHttpNetworkFetcher extends
    * after request cancellation, then the exception is interpreted as successful cancellation
    * and onCancellation is called. Otherwise onFailure is called.
    */
-  private void handleException(final Call call, final Exception e, final Callback callback) {
+  /* PACKAGE */ void handleException(final Call call, final Exception e, final Callback callback) {
     if (call.isCanceled()) {
       callback.onCancellation();
     } else {

--- a/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
@@ -48,7 +48,7 @@ public class OkHttpNetworkFetcher extends
     }
   }
 
-  private static final String TAG = "OkHttpNetworkFetchProducer";
+  /* PACKAGE */ static final String TAG = "OkHttpNetworkFetchProducer";
   private static final String QUEUE_TIME = "queue_time";
   private static final String FETCH_TIME = "fetch_time";
   private static final String TOTAL_TIME = "total_time";
@@ -56,7 +56,7 @@ public class OkHttpNetworkFetcher extends
 
   private final OkHttpClient mOkHttpClient;
 
-  private Executor mCancellationExecutor;
+  /* PACKAGE */ Executor mCancellationExecutor;
 
   /**
    * @param okHttpClient client to use
@@ -160,7 +160,7 @@ public class OkHttpNetworkFetcher extends
    * after request cancellation, then the exception is interpreted as successful cancellation
    * and onCancellation is called. Otherwise onFailure is called.
    */
-  private void handleException(final Call call, final Exception e, final Callback callback) {
+  /* PACKAGE */ void handleException(final Call call, final Exception e, final Callback callback) {
     if (call.isCanceled()) {
       callback.onCancellation();
     } else {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
@@ -36,15 +36,15 @@ import bolts.Task;
  * read/writes.
  */
 public class BufferedDiskCache {
-  private static final Class<?> TAG = BufferedDiskCache.class;
+  /* PACKAGE */ static final Class<?> TAG = BufferedDiskCache.class;
 
-  private final FileCache mFileCache;
-  private final PooledByteBufferFactory mPooledByteBufferFactory;
-  private final PooledByteStreams mPooledByteStreams;
-  private final Executor mReadExecutor;
-  private final Executor mWriteExecutor;
-  private final StagingArea mStagingArea;
-  private final ImageCacheStatsTracker mImageCacheStatsTracker;
+  /* PACKAGE */ final FileCache mFileCache;
+  /* PACKAGE */ final PooledByteBufferFactory mPooledByteBufferFactory;
+  /* PACKAGE */ final PooledByteStreams mPooledByteStreams;
+  /* PACKAGE */ final Executor mReadExecutor;
+  /* PACKAGE */ final Executor mWriteExecutor;
+  /* PACKAGE */ final StagingArea mStagingArea;
+  /* PACKAGE */ final ImageCacheStatsTracker mImageCacheStatsTracker;
 
   public BufferedDiskCache(
       FileCache fileCache,
@@ -144,7 +144,7 @@ public class BufferedDiskCache {
    * @param key
    * @return true if the image is found in staging area or File cache, false if not found
    */
-  private boolean checkInStagingAreaAndFileCache(final CacheKey key) {
+  /* PACKAGE */ boolean checkInStagingAreaAndFileCache(final CacheKey key) {
     EncodedImage result = mStagingArea.get(key);
     if (result != null) {
       result.close();
@@ -318,7 +318,7 @@ public class BufferedDiskCache {
   /**
    * Performs disk cache read. In case of any exception null is returned.
    */
-  private PooledByteBuffer readFromDiskCache(final CacheKey key) throws IOException {
+  /* PACKAGE */ PooledByteBuffer readFromDiskCache(final CacheKey key) throws IOException {
     try {
       FLog.v(TAG, "Disk cache read for %s", key.toString());
 
@@ -356,7 +356,7 @@ public class BufferedDiskCache {
    * Writes to disk cache
    * @throws IOException
    */
-  private void writeToDiskCache(
+  /* PACKAGE */ void writeToDiskCache(
       final CacheKey key,
       final EncodedImage encodedImage) {
     FLog.v(TAG, "About to write to disk-cache for key %s", key.toString());

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -60,7 +60,7 @@ public class ImagePipeline {
   private final MemoryCache<CacheKey, CloseableImage> mBitmapMemoryCache;
   private final MemoryCache<CacheKey, PooledByteBuffer> mEncodedMemoryCache;
   private final BufferedDiskCache mMainBufferedDiskCache;
-  private final BufferedDiskCache mSmallImageBufferedDiskCache;
+  /* PACKAGE */ final BufferedDiskCache mSmallImageBufferedDiskCache;
   private final CacheKeyFactory mCacheKeyFactory;
   private final ThreadHandoffProducerQueue mThreadHandoffProducerQueue;
   private AtomicLong mIdCounter;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -91,7 +91,7 @@ public class ImagePipelineConfig {
   private static DefaultImageRequestConfig
       sDefaultImageRequestConfig = new DefaultImageRequestConfig();
 
-  private ImagePipelineConfig(Builder builder) {
+  /* PACKAGE */ ImagePipelineConfig(Builder builder) {
     mAnimatedImageFactory = builder.mAnimatedImageFactory;
     mBitmapMemoryCacheParamsSupplier =
         builder.mBitmapMemoryCacheParamsSupplier == null ?
@@ -313,7 +313,7 @@ public class ImagePipelineConfig {
 
     private boolean mProgressiveRenderingEnabled = false;
 
-    private DefaultImageRequestConfig() {
+    /* PACKAGE */ DefaultImageRequestConfig() {
     }
 
     public void setProgressiveRenderingEnabled(boolean progressiveRenderingEnabled) {
@@ -327,32 +327,32 @@ public class ImagePipelineConfig {
 
   public static class Builder {
 
-    private AnimatedImageFactory mAnimatedImageFactory;
-    private Bitmap.Config mBitmapConfig;
-    private Supplier<MemoryCacheParams> mBitmapMemoryCacheParamsSupplier;
-    private CacheKeyFactory mCacheKeyFactory;
-    private final Context mContext;
-    private boolean mDownsampleEnabled = false;
-    private boolean mDecodeMemoryFileEnabled;
-    private Supplier<MemoryCacheParams> mEncodedMemoryCacheParamsSupplier;
-    private ExecutorSupplier mExecutorSupplier;
-    private ImageCacheStatsTracker mImageCacheStatsTracker;
-    private ImageDecoder mImageDecoder;
-    private Supplier<Boolean> mIsPrefetchEnabledSupplier;
-    private DiskCacheConfig mMainDiskCacheConfig;
-    private MemoryTrimmableRegistry mMemoryTrimmableRegistry;
-    private NetworkFetcher mNetworkFetcher;
-    private PlatformBitmapFactory mPlatformBitmapFactory;
-    private PoolFactory mPoolFactory;
-    private ProgressiveJpegConfig mProgressiveJpegConfig;
-    private Set<RequestListener> mRequestListeners;
-    private boolean mResizeAndRotateEnabledForNetwork = true;
-    private DiskCacheConfig mSmallImageDiskCacheConfig;
-    private FileCacheFactory mFileCacheFactory;
-    private final ImagePipelineExperiments.Builder mExperimentsBuilder
+    /* PACKAGE */ AnimatedImageFactory mAnimatedImageFactory;
+    /* PACKAGE */ Bitmap.Config mBitmapConfig;
+    /* PACKAGE */ Supplier<MemoryCacheParams> mBitmapMemoryCacheParamsSupplier;
+    /* PACKAGE */ CacheKeyFactory mCacheKeyFactory;
+    /* PACKAGE */ final Context mContext;
+    /* PACKAGE */ boolean mDownsampleEnabled = false;
+    /* PACKAGE */ boolean mDecodeMemoryFileEnabled;
+    /* PACKAGE */ Supplier<MemoryCacheParams> mEncodedMemoryCacheParamsSupplier;
+    /* PACKAGE */ ExecutorSupplier mExecutorSupplier;
+    /* PACKAGE */ ImageCacheStatsTracker mImageCacheStatsTracker;
+    /* PACKAGE */ ImageDecoder mImageDecoder;
+    /* PACKAGE */ Supplier<Boolean> mIsPrefetchEnabledSupplier;
+    /* PACKAGE */ DiskCacheConfig mMainDiskCacheConfig;
+    /* PACKAGE */ MemoryTrimmableRegistry mMemoryTrimmableRegistry;
+    /* PACKAGE */ NetworkFetcher mNetworkFetcher;
+    /* PACKAGE */ PlatformBitmapFactory mPlatformBitmapFactory;
+    /* PACKAGE */ PoolFactory mPoolFactory;
+    /* PACKAGE */ ProgressiveJpegConfig mProgressiveJpegConfig;
+    /* PACKAGE */ Set<RequestListener> mRequestListeners;
+    /* PACKAGE */ boolean mResizeAndRotateEnabledForNetwork = true;
+    /* PACKAGE */ DiskCacheConfig mSmallImageDiskCacheConfig;
+    /* PACKAGE */ FileCacheFactory mFileCacheFactory;
+    /* PACKAGE */ final ImagePipelineExperiments.Builder mExperimentsBuilder
         = new ImagePipelineExperiments.Builder(this);
 
-    private Builder(Context context) {
+    /* PACKAGE */ Builder(Context context) {
       // Doesn't use a setter as always required.
       mContext = Preconditions.checkNotNull(context);
     }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineExperiments.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineExperiments.java
@@ -30,7 +30,7 @@ public class ImagePipelineExperiments {
   private final boolean mExternalCreatedBitmapLogEnabled;
   private final WebpBitmapFactory.WebpErrorLogger mWebpErrorLogger;
 
-  private ImagePipelineExperiments(Builder builder, ImagePipelineConfig.Builder configBuilder) {
+  /* PACKAGE */ ImagePipelineExperiments(Builder builder, ImagePipelineConfig.Builder configBuilder) {
     mForceSmallCacheThresholdBytes = builder.mForceSmallCacheThresholdBytes;
     mWebpSupportEnabled = builder.mWebpSupportEnabled && sWebpLibraryPresent;
     mDecodeFileDescriptorEnabled = configBuilder.isDownsampleEnabled() &&
@@ -78,14 +78,14 @@ public class ImagePipelineExperiments {
 
     private static final int DEFAULT_MAX_SIMULTANEOUS_FILE_FETCH_AND_RESIZE = 5;
 
-    private final ImagePipelineConfig.Builder mConfigBuilder;
-    private int mForceSmallCacheThresholdBytes = 0;
-    private boolean mWebpSupportEnabled = false;
-    private @WebpTranscodeProducer.EnhancedTranscodingType int mEnhancedWebpTranscodingType;
-    private boolean mDecodeFileDescriptorEnabled = false;
-    private boolean mExternalCreatedBitmapLogEnabled = false;
-    private int mThrottlingMaxSimultaneousRequests = DEFAULT_MAX_SIMULTANEOUS_FILE_FETCH_AND_RESIZE;
-    private WebpBitmapFactory.WebpErrorLogger mWebpErrorLogger;
+    /* PACKAGE */ final ImagePipelineConfig.Builder mConfigBuilder;
+    /* PACKAGE */ int mForceSmallCacheThresholdBytes = 0;
+    /* PACKAGE */ boolean mWebpSupportEnabled = false;
+    /* PACKAGE */ @WebpTranscodeProducer.EnhancedTranscodingType int mEnhancedWebpTranscodingType;
+    /* PACKAGE */ boolean mDecodeFileDescriptorEnabled = false;
+    /* PACKAGE */ boolean mExternalCreatedBitmapLogEnabled = false;
+    /* PACKAGE */ int mThrottlingMaxSimultaneousRequests = DEFAULT_MAX_SIMULTANEOUS_FILE_FETCH_AND_RESIZE;
+    /* PACKAGE */ WebpBitmapFactory.WebpErrorLogger mWebpErrorLogger;
 
     public Builder(ImagePipelineConfig.Builder configBuilder) {
       mConfigBuilder = configBuilder;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/datasource/AbstractProducerToDataSourceAdapter.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/datasource/AbstractProducerToDataSourceAdapter.java
@@ -80,7 +80,7 @@ public abstract class AbstractProducerToDataSourceAdapter<T> extends AbstractDat
     }
   }
 
-  private void onFailureImpl(Throwable throwable) {
+  /* PACKAGE */ void onFailureImpl(Throwable throwable) {
     if (super.setFailure(throwable)) {
       mRequestListener.onRequestFailure(
           mSettableProducerContext.getImageRequest(),
@@ -90,7 +90,7 @@ public abstract class AbstractProducerToDataSourceAdapter<T> extends AbstractDat
     }
   }
 
-  private synchronized void onCancellationImpl() {
+  /* PACKAGE */ synchronized void onCancellationImpl() {
     Preconditions.checkState(isClosed());
   }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/datasource/ListDataSource.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/datasource/ListDataSource.java
@@ -112,7 +112,7 @@ public class ListDataSource<T> extends AbstractDataSource<List<CloseableReferenc
     setProgress(progress / mDataSources.length);
   }
 
-  private class InternalDataSubscriber implements DataSubscriber<CloseableReference<T>> {
+  /* PACKAGE */ class InternalDataSubscriber implements DataSubscriber<CloseableReference<T>> {
     @GuardedBy("InternalDataSubscriber.this")
     boolean mFinished = false;
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/SimpleProgressiveJpegConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/SimpleProgressiveJpegConfig.java
@@ -27,7 +27,7 @@ public class SimpleProgressiveJpegConfig implements ProgressiveJpegConfig {
     int getGoodEnoughScanNumber();
   }
 
-  private static class DefaultDynamicValueConfig implements DynamicValueConfig {
+  /* PACKAGE */ static class DefaultDynamicValueConfig implements DynamicValueConfig {
     public List<Integer> getScansToDecode() {
       return Collections.EMPTY_LIST;
     }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/PoolConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/PoolConfig.java
@@ -32,7 +32,7 @@ public class PoolConfig {
   private final PoolParams mSmallByteArrayPoolParams;
   private final PoolStatsTracker mSmallByteArrayPoolStatsTracker;
 
-  private PoolConfig(Builder builder) {
+  /* PACKAGE */ PoolConfig(Builder builder) {
     mBitmapPoolParams =
         builder.mBitmapPoolParams == null ?
             DefaultBitmapPoolParams.get() :
@@ -105,16 +105,16 @@ public class PoolConfig {
 
   public static class Builder {
 
-    private PoolParams mBitmapPoolParams;
-    private PoolStatsTracker mBitmapPoolStatsTracker;
-    private PoolParams mFlexByteArrayPoolParams;
-    private MemoryTrimmableRegistry mMemoryTrimmableRegistry;
-    private PoolParams mNativeMemoryChunkPoolParams;
-    private PoolStatsTracker mNativeMemoryChunkPoolStatsTracker;
-    private PoolParams mSmallByteArrayPoolParams;
-    private PoolStatsTracker mSmallByteArrayPoolStatsTracker;
+    /* PACKAGE */ PoolParams mBitmapPoolParams;
+    /* PACKAGE */ PoolStatsTracker mBitmapPoolStatsTracker;
+    /* PACKAGE */ PoolParams mFlexByteArrayPoolParams;
+    /* PACKAGE */ MemoryTrimmableRegistry mMemoryTrimmableRegistry;
+    /* PACKAGE */ PoolParams mNativeMemoryChunkPoolParams;
+    /* PACKAGE */ PoolStatsTracker mNativeMemoryChunkPoolStatsTracker;
+    /* PACKAGE */ PoolParams mSmallByteArrayPoolParams;
+    /* PACKAGE */ PoolStatsTracker mSmallByteArrayPoolStatsTracker;
 
-    private Builder() {
+    /* PACKAGE */ Builder() {
     }
 
     public Builder setBitmapPoolParams(PoolParams bitmapPoolParams) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/AddImageTransformMetaDataProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/AddImageTransformMetaDataProducer.java
@@ -32,7 +32,7 @@ public class AddImageTransformMetaDataProducer implements Producer<EncodedImage>
   private static class AddImageTransformMetaDataConsumer extends DelegatingConsumer<
       EncodedImage, EncodedImage> {
 
-    private AddImageTransformMetaDataConsumer(Consumer<EncodedImage> consumer) {
+    /* PACKAGE */ AddImageTransformMetaDataConsumer(Consumer<EncodedImage> consumer) {
       super(consumer);
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BitmapMemoryCacheProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BitmapMemoryCacheProducer.java
@@ -27,7 +27,7 @@ public class BitmapMemoryCacheProducer implements Producer<CloseableReference<Cl
   public static final String PRODUCER_NAME = "BitmapMemoryCacheProducer";
   public static final String EXTRA_CACHED_VALUE_FOUND = ProducerConstants.EXTRA_CACHED_VALUE_FOUND;
 
-  private final MemoryCache<CacheKey, CloseableImage> mMemoryCache;
+  /* PACKAGE */ final MemoryCache<CacheKey, CloseableImage> mMemoryCache;
   private final CacheKeyFactory mCacheKeyFactory;
   private final Producer<CloseableReference<CloseableImage>> mInputProducer;
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BranchOnSeparateImagesProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BranchOnSeparateImagesProducer.java
@@ -21,7 +21,7 @@ import com.facebook.imagepipeline.request.ImageRequest;
 public class BranchOnSeparateImagesProducer
     implements Producer<EncodedImage> {
   private final Producer<EncodedImage> mInputProducer1;
-  private final Producer<EncodedImage> mInputProducer2;
+  /* PACKAGE */ final Producer<EncodedImage> mInputProducer2;
 
   public BranchOnSeparateImagesProducer(
       Producer<EncodedImage> inputProducer1, Producer<EncodedImage> inputProducer2) {
@@ -41,7 +41,7 @@ public class BranchOnSeparateImagesProducer
 
     private ProducerContext mProducerContext;
 
-    private OnFirstImageConsumer(
+    /* PACKAGE */ OnFirstImageConsumer(
         Consumer<EncodedImage> consumer,
         ProducerContext producerContext) {
       super(consumer);

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
@@ -45,18 +45,18 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
   public static final String PRODUCER_NAME = "DecodeProducer";
 
   // keys for extra map
-  private static final String BITMAP_SIZE_KEY = "bitmapSize";
-  private static final String HAS_GOOD_QUALITY_KEY = "hasGoodQuality";
-  private static final String IMAGE_TYPE_KEY = "imageType";
-  private static final String IS_FINAL_KEY = "isFinal";
+  /* PACKAGE */ static final String BITMAP_SIZE_KEY = "bitmapSize";
+  /* PACKAGE */ static final String HAS_GOOD_QUALITY_KEY = "hasGoodQuality";
+  /* PACKAGE */ static final String IMAGE_TYPE_KEY = "imageType";
+  /* PACKAGE */ static final String IS_FINAL_KEY = "isFinal";
 
   private final ByteArrayPool mByteArrayPool;
-  private final Executor mExecutor;
-  private final ImageDecoder mImageDecoder;
+  /* PACKAGE */ final Executor mExecutor;
+  /* PACKAGE */ final ImageDecoder mImageDecoder;
   private final ProgressiveJpegConfig mProgressiveJpegConfig;
   private final Producer<EncodedImage> mInputProducer;
-  private final boolean mDownsampleEnabled;
-  private final boolean mDownsampleEnabledForNetwork;
+  /* PACKAGE */ final boolean mDownsampleEnabled;
+  /* PACKAGE */ final boolean mDownsampleEnabledForNetwork;
 
   public DecodeProducer(
       final ByteArrayPool byteArrayPool,
@@ -97,14 +97,14 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
   private abstract class ProgressiveDecoder extends DelegatingConsumer<
       EncodedImage, CloseableReference<CloseableImage>> {
 
-    private final ProducerContext mProducerContext;
+    /* PACKAGE */ final ProducerContext mProducerContext;
     private final ProducerListener mProducerListener;
     private final ImageDecodeOptions mImageDecodeOptions;
 
     @GuardedBy("this")
     private boolean mIsFinished;
 
-    private final JobScheduler mJobScheduler;
+    /* PACKAGE */ final JobScheduler mJobScheduler;
 
     public ProgressiveDecoder(
         final Consumer<CloseableReference<CloseableImage>> consumer,
@@ -177,7 +177,7 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
     }
 
     /** Performs the decode synchronously. */
-    private void doDecode(EncodedImage encodedImage, boolean isLast) {
+    /* PACKAGE */ void doDecode(EncodedImage encodedImage, boolean isLast) {
       if (isFinished() || !EncodedImage.isValid(encodedImage)) {
         return;
       }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DiskCacheProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DiskCacheProducer.java
@@ -39,12 +39,12 @@ public class DiskCacheProducer implements Producer<EncodedImage> {
   public static final String PRODUCER_NAME = "DiskCacheProducer";
   public static final String EXTRA_CACHED_VALUE_FOUND = ProducerConstants.EXTRA_CACHED_VALUE_FOUND;
 
-  private final BufferedDiskCache mDefaultBufferedDiskCache;
-  private final BufferedDiskCache mSmallImageBufferedDiskCache;
+  /* PACKAGE */ final BufferedDiskCache mDefaultBufferedDiskCache;
+  /* PACKAGE */ final BufferedDiskCache mSmallImageBufferedDiskCache;
   private final CacheKeyFactory mCacheKeyFactory;
   private final Producer<EncodedImage> mInputProducer;
-  private final boolean mChooseCacheByImageSize;
-  private final int mForceSmallCacheThresholdBytes;
+  /* PACKAGE */ final boolean mChooseCacheByImageSize;
+  /* PACKAGE */ final int mForceSmallCacheThresholdBytes;
 
   public DiskCacheProducer(
       BufferedDiskCache defaultBufferedDiskCache,
@@ -156,12 +156,12 @@ public class DiskCacheProducer implements Producer<EncodedImage> {
     };
   }
 
-  private static boolean isTaskCancelled(Task<?> task) {
+  /* PACKAGE */ static boolean isTaskCancelled(Task<?> task) {
     return task.isCancelled() ||
         (task.isFaulted() && task.getError() instanceof CancellationException);
   }
 
-  private void maybeStartInputProducer(
+  /* PACKAGE */ void maybeStartInputProducer(
       Consumer<EncodedImage> consumerOfDiskCacheProducer,
       Consumer<EncodedImage> consumerOfInputProducer,
       ProducerContext producerContext) {
@@ -208,7 +208,7 @@ public class DiskCacheProducer implements Producer<EncodedImage> {
     private final BufferedDiskCache mCache;
     private final CacheKey mCacheKey;
 
-    private DiskCacheConsumer(
+    /* PACKAGE */ DiskCacheConsumer(
         final Consumer<EncodedImage> consumer,
         final BufferedDiskCache cache,
         final CacheKey cacheKey) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/EncodedMemoryCacheProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/EncodedMemoryCacheProducer.java
@@ -28,7 +28,7 @@ public class EncodedMemoryCacheProducer implements Producer<EncodedImage> {
   public static final String PRODUCER_NAME = "EncodedMemoryCacheProducer";
   public static final String EXTRA_CACHED_VALUE_FOUND = ProducerConstants.EXTRA_CACHED_VALUE_FOUND;
 
-  private final MemoryCache<CacheKey, PooledByteBuffer> mMemoryCache;
+  /* PACKAGE */ final MemoryCache<CacheKey, PooledByteBuffer> mMemoryCache;
   private final CacheKeyFactory mCacheKeyFactory;
   private final Producer<EncodedImage> mInputProducer;
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/JobScheduler.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/JobScheduler.java
@@ -184,11 +184,11 @@ public class JobScheduler {
     }
   }
 
-  private void submitJob() {
+  /* PACKAGE */ void submitJob() {
     mExecutor.execute(mDoJobRunnable);
   }
 
-  private void doJob() {
+  /* PACKAGE */ void doJob() {
     long now = SystemClock.uptimeMillis();
     EncodedImage input;
     boolean isLast;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalExifThumbnailProducer.java
@@ -49,7 +49,7 @@ public class LocalExifThumbnailProducer implements ThumbnailProducer<EncodedImag
   @VisibleForTesting static final String CREATED_THUMBNAIL = "createdThumbnail";
 
   private final Executor mExecutor;
-  private final PooledByteBufferFactory mPooledByteBufferFactory;
+  /* PACKAGE */ final PooledByteBufferFactory mPooledByteBufferFactory;
   private final ContentResolver mContentResolver;
 
   public LocalExifThumbnailProducer(
@@ -138,7 +138,7 @@ public class LocalExifThumbnailProducer implements ThumbnailProducer<EncodedImag
     return null;
   }
 
-  private EncodedImage buildEncodedImage(
+  /* PACKAGE */ EncodedImage buildEncodedImage(
       PooledByteBuffer imageBytes,
       ExifInterface exifInterface) {
     Pair<Integer, Integer> dimensions =

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -95,7 +95,7 @@ public class LocalVideoThumbnailProducer implements
     mExecutor.execute(cancellableProducerRunnable);
   }
 
-  private static int calculateKind(ImageRequest imageRequest) {
+    /* PACKAGE */ static int calculateKind(ImageRequest imageRequest) {
     if (imageRequest.getPreferredWidth() > 96 || imageRequest.getPreferredHeight() > 96) {
       return MediaStore.Images.Thumbnails.MINI_KIND;
     }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/MultiplexProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/MultiplexProducer.java
@@ -53,7 +53,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
    */
   @GuardedBy("this")
   @VisibleForTesting final Map<K, Multiplexer> mMultiplexers;
-  private final Producer<T> mInputProducer;
+  /* PACKAGE */ final Producer<T> mInputProducer;
 
   protected MultiplexProducer(Producer<T> inputProducer) {
     mInputProducer = inputProducer;
@@ -88,7 +88,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     }
   }
 
-  private synchronized Multiplexer getExistingMultiplexer(K key) {
+  /* PACKAGE */ synchronized Multiplexer getExistingMultiplexer(K key) {
     return mMultiplexers.get(key);
   }
 
@@ -98,7 +98,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     return multiplexer;
   }
 
-  private synchronized void removeMultiplexer(K key, Multiplexer multiplexer) {
+  /* PACKAGE */ synchronized void removeMultiplexer(K key, Multiplexer multiplexer) {
     if (mMultiplexers.get(key) == multiplexer) {
       mMultiplexers.remove(key);
     }
@@ -140,7 +140,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
      *   <li> cancellation notification is received and mConsumerContextPairs is empty </li>
      * </ul>
      */
-    private final CopyOnWriteArraySet<Pair<Consumer<T>, ProducerContext>> mConsumerContextPairs;
+    /* PACKAGE */ final CopyOnWriteArraySet<Pair<Consumer<T>, ProducerContext>> mConsumerContextPairs;
 
     @GuardedBy("Multiplexer.this")
     @Nullable
@@ -157,7 +157,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
      */
     @GuardedBy("Multiplexer.this")
     @Nullable
-    private BaseProducerContext mMultiplexProducerContext;
+    /* PACKAGE */ BaseProducerContext mMultiplexProducerContext;
 
     /**
      * Currently used consumer of next producer.
@@ -305,7 +305,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
      * the data. If all consumers are cancelled, then this multiplexer is removed from mRequest
      * map to clean up.
      */
-    private void startInputProducerIfHasAttachedConsumers() {
+    /* PACKAGE */ void startInputProducerIfHasAttachedConsumers() {
       BaseProducerContext multiplexProducerContext;
       ForwardingConsumer forwardingConsumer;
       synchronized (Multiplexer.this) {
@@ -339,7 +339,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     }
 
     @Nullable
-    private synchronized List<ProducerContextCallbacks> updateIsPrefetch() {
+    /* PACKAGE */ synchronized List<ProducerContextCallbacks> updateIsPrefetch() {
       if (mMultiplexProducerContext == null) {
         return null;
       }
@@ -356,7 +356,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     }
 
     @Nullable
-    private synchronized List<ProducerContextCallbacks> updateIsIntermediateResultExpected() {
+    /* PACKAGE */ synchronized List<ProducerContextCallbacks> updateIsIntermediateResultExpected() {
       if (mMultiplexProducerContext == null) {
         return null;
       }
@@ -374,7 +374,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     }
 
     @Nullable
-    private synchronized List<ProducerContextCallbacks> updatePriority() {
+    /* PACKAGE */ synchronized List<ProducerContextCallbacks> updatePriority() {
       if (mMultiplexProducerContext == null) {
         return null;
       }
@@ -493,7 +493,7 @@ public abstract class MultiplexProducer<K, T extends Closeable> implements Produ
     /**
      * Forwards {@link Consumer} methods to Multiplexer.
      */
-    private class ForwardingConsumer extends BaseConsumer<T> {
+    /* PACKAGE */ class ForwardingConsumer extends BaseConsumer<T> {
       @Override
       protected void onNewResultImpl(T newResult, boolean isLast) {
         Multiplexer.this.onNextResult(this, newResult, isLast);

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/NetworkFetchProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/NetworkFetchProducer.java
@@ -84,7 +84,7 @@ public class NetworkFetchProducer implements Producer<EncodedImage> {
         });
   }
 
-  private void onResponse(
+  /* PACKAGE */ void onResponse(
       FetchState fetchState,
       InputStream responseData,
       int responseContentLength)
@@ -172,13 +172,13 @@ public class NetworkFetchProducer implements Producer<EncodedImage> {
     }
   }
 
-  private void onFailure(FetchState fetchState, Throwable e) {
+  /* PACKAGE */ void onFailure(FetchState fetchState, Throwable e) {
     fetchState.getListener()
         .onProducerFinishWithFailure(fetchState.getId(), PRODUCER_NAME, e, null);
     fetchState.getConsumer().onFailure(e);
   }
 
-  private void onCancellation(FetchState fetchState) {
+  /* PACKAGE */ void onCancellation(FetchState fetchState) {
     fetchState.getListener()
         .onProducerFinishWithCancellation(fetchState.getId(), PRODUCER_NAME, null);
     fetchState.getConsumer().onCancellation();

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/PostprocessorProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/PostprocessorProducer.java
@@ -40,8 +40,8 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
   @VisibleForTesting static final String POSTPROCESSOR = "Postprocessor";
 
   private final Producer<CloseableReference<CloseableImage>> mInputProducer;
-  private final PlatformBitmapFactory mBitmapFactory;
-  private final Executor mExecutor;
+  /* PACKAGE */ final PlatformBitmapFactory mBitmapFactory;
+  /* PACKAGE */ final Executor mExecutor;
 
   public PostprocessorProducer(
       Producer<CloseableReference<CloseableImage>> inputProducer,
@@ -87,11 +87,11 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
     private boolean mIsClosed;
     @GuardedBy("PostprocessorConsumer.this")
     @Nullable
-    private CloseableReference<CloseableImage> mSourceImageRef = null;
+    /* PACKAGE */ CloseableReference<CloseableImage> mSourceImageRef = null;
     @GuardedBy("PostprocessorConsumer.this")
-    private boolean mIsLast = false;
+    /* PACKAGE */ boolean mIsLast = false;
     @GuardedBy("PostprocessorConsumer.this")
-    private boolean mIsDirty = false;
+    /* PACKAGE */ boolean mIsDirty = false;
     @GuardedBy("PostprocessorConsumer.this")
     private boolean mIsPostProcessingRunning = false;
 
@@ -185,7 +185,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
           });
     }
 
-    private void clearRunningAndStartIfDirty() {
+    /* PACKAGE */ void clearRunningAndStartIfDirty() {
       boolean shouldExecuteAgain;
       synchronized (PostprocessorConsumer.this) {
         mIsPostProcessingRunning = false;
@@ -205,7 +205,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
       return false;
     }
 
-    private void doPostprocessing(
+    /* PACKAGE */ void doPostprocessing(
         CloseableReference<CloseableImage> sourceImageRef,
         boolean isLast) {
       Preconditions.checkArgument(CloseableReference.isValid(sourceImageRef));
@@ -271,7 +271,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
       }
     }
 
-    private void maybeNotifyOnCancellation() {
+    /* PACKAGE */ void maybeNotifyOnCancellation() {
       if (close()) {
         getConsumer().onCancellation();
       }
@@ -303,7 +303,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
       CloseableReference<CloseableImage>,
       CloseableReference<CloseableImage>> {
 
-    private SingleUsePostprocessorConsumer(PostprocessorConsumer postprocessorConsumer) {
+    /* PACKAGE */ SingleUsePostprocessorConsumer(PostprocessorConsumer postprocessorConsumer) {
       super(postprocessorConsumer);
     }
 
@@ -338,7 +338,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
     @Nullable
     private CloseableReference<CloseableImage> mSourceImageRef = null;
 
-    private RepeatedPostprocessorConsumer(
+    /* PACKAGE */ RepeatedPostprocessorConsumer(
         PostprocessorConsumer postprocessorConsumer,
         RepeatedPostprocessor repeatedPostprocessor,
         ProducerContext context) {
@@ -411,7 +411,7 @@ public class PostprocessorProducer implements Producer<CloseableReference<Closea
       CloseableReference.closeSafely(oldSourceImageRef);
     }
 
-    private boolean close() {
+    /* PACKAGE */ boolean close() {
       CloseableReference<CloseableImage> oldSourceImageRef;
       synchronized (RepeatedPostprocessorConsumer.this) {
         if (mIsClosed) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/RemoveImageTransformMetaDataProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/RemoveImageTransformMetaDataProducer.java
@@ -38,7 +38,7 @@ public class RemoveImageTransformMetaDataProducer
   private class RemoveImageTransformMetaDataConsumer extends DelegatingConsumer<EncodedImage,
           CloseableReference<PooledByteBuffer>> {
 
-    private RemoveImageTransformMetaDataConsumer(
+    /* PACKAGE */ RemoveImageTransformMetaDataConsumer(
         Consumer<CloseableReference<PooledByteBuffer>> consumer) {
       super(consumer);
     }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -43,17 +43,17 @@ import com.facebook.imagepipeline.request.ImageRequest;
  */
 public class ResizeAndRotateProducer implements Producer<EncodedImage> {
   public static final String PRODUCER_NAME = "ResizeAndRotateProducer";
-  private static final String ORIGINAL_SIZE_KEY = "Original size";
-  private static final String REQUESTED_SIZE_KEY = "Requested size";
-  private static final String FRACTION_KEY = "Fraction";
+  /* PACKAGE */ static final String ORIGINAL_SIZE_KEY = "Original size";
+  /* PACKAGE */ static final String REQUESTED_SIZE_KEY = "Requested size";
+  /* PACKAGE */ static final String FRACTION_KEY = "Fraction";
 
   @VisibleForTesting static final int DEFAULT_JPEG_QUALITY = 85;
   @VisibleForTesting static final int MAX_JPEG_SCALE_NUMERATOR = JpegTranscoder.SCALE_DENOMINATOR;
   @VisibleForTesting static final int MIN_TRANSFORM_INTERVAL_MS = 100;
 
-  private final Executor mExecutor;
-  private final PooledByteBufferFactory mPooledByteBufferFactory;
-  private final boolean mResizingEnabled;
+  /* PACKAGE */ final Executor mExecutor;
+  /* PACKAGE */ final PooledByteBufferFactory mPooledByteBufferFactory;
+  /* PACKAGE */ final boolean mResizingEnabled;
   private final Producer<EncodedImage> mInputProducer;
 
   public ResizeAndRotateProducer(
@@ -76,10 +76,10 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
 
   private class TransformingConsumer extends DelegatingConsumer<EncodedImage, EncodedImage> {
 
-    private final ProducerContext mProducerContext;
-    private boolean mIsCancelled;
+    /* PACKAGE */ final ProducerContext mProducerContext;
+    /* PACKAGE */ boolean mIsCancelled;
 
-    private final JobScheduler mJobScheduler;
+    /* PACKAGE */ final JobScheduler mJobScheduler;
 
     public TransformingConsumer(
         final Consumer<EncodedImage> consumer,
@@ -145,7 +145,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
       }
     }
 
-    private void doTransform(EncodedImage encodedImage, boolean isLast) {
+    /* PACKAGE */ void doTransform(EncodedImage encodedImage, boolean isLast) {
       mProducerContext.getListener().onProducerStart(mProducerContext.getId(), PRODUCER_NAME);
       ImageRequest imageRequest = mProducerContext.getImageRequest();
       PooledByteBufferOutputStream outputStream = mPooledByteBufferFactory.newOutputStream();
@@ -215,7 +215,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
     }
   }
 
-  private static TriState shouldTransform(
+  /* PACKAGE */ static TriState shouldTransform(
       ImageRequest request,
       EncodedImage encodedImage,
       boolean resizingEnabled) {
@@ -256,7 +256,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
     return (int) (roundUpFraction + maxRatio * JpegTranscoder.SCALE_DENOMINATOR);
   }
 
-  private static int getScaleNumerator(
+  /* PACKAGE */ static int getScaleNumerator(
       ImageRequest imageRequest,
       EncodedImage encodedImage,
       boolean resizingEnabled) {
@@ -283,7 +283,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
     return (numerator < 1) ? 1 : numerator;
   }
 
-  private static int getRotationAngle(RotationOptions rotationOptions, EncodedImage encodedImage) {
+  /* PACKAGE */ static int getRotationAngle(RotationOptions rotationOptions, EncodedImage encodedImage) {
     if (rotationOptions.useImageMetadata()) {
       int rotationAngle = encodedImage.getRotationAngle();
       switch (rotationAngle) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThreadHandoffProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThreadHandoffProducer.java
@@ -19,8 +19,8 @@ public class ThreadHandoffProducer<T> implements Producer<T> {
 
   public static final String PRODUCER_NAME = "BackgroundThreadHandoffProducer";
 
-  private final Producer<T> mInputProducer;
-  private final ThreadHandoffProducerQueue mThreadHandoffProducerQueue;
+  /* PACKAGE */ final Producer<T> mInputProducer;
+  /* PACKAGE */ final ThreadHandoffProducerQueue mThreadHandoffProducerQueue;
 
   public ThreadHandoffProducer(final Producer<T> inputProducer,
                                final  ThreadHandoffProducerQueue inputThreadHandoffProducerQueue) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThrottlingProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThrottlingProducer.java
@@ -30,10 +30,10 @@ public class ThrottlingProducer<T> implements Producer<T> {
   private final int mMaxSimultaneousRequests;
 
   @GuardedBy("this")
-  private int mNumCurrentRequests;
+  /* PACKAGE */ int mNumCurrentRequests;
   @GuardedBy("this")
-  private final ConcurrentLinkedQueue<Pair<Consumer<T>, ProducerContext>> mPendingRequests;
-  private final Executor mExecutor;
+  /* PACKAGE */ final ConcurrentLinkedQueue<Pair<Consumer<T>, ProducerContext>> mPendingRequests;
+  /* PACKAGE */ final Executor mExecutor;
 
   public ThrottlingProducer(
       int maxSimultaneousRequests,
@@ -75,7 +75,7 @@ public class ThrottlingProducer<T> implements Producer<T> {
 
   private class ThrottlerConsumer extends DelegatingConsumer<T, T> {
 
-    private ThrottlerConsumer(Consumer<T> consumer) {
+    /* PACKAGE */ ThrottlerConsumer(Consumer<T> consumer) {
       super(consumer);
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThumbnailBranchProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ThumbnailBranchProducer.java
@@ -90,7 +90,7 @@ public class ThumbnailBranchProducer implements Producer<EncodedImage> {
     }
   }
 
-  private boolean produceResultsFromThumbnailProducer(
+  /* PACKAGE */ boolean produceResultsFromThumbnailProducer(
       int startIndex,
       Consumer<EncodedImage> consumer,
       ProducerContext context) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/WebpTranscodeProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/WebpTranscodeProducer.java
@@ -53,9 +53,9 @@ public class WebpTranscodeProducer implements Producer<EncodedImage> {
   private static final int DEFAULT_JPEG_QUALITY = 80;
 
   private final Executor mExecutor;
-  private final PooledByteBufferFactory mPooledByteBufferFactory;
+  /* PACKAGE */ final PooledByteBufferFactory mPooledByteBufferFactory;
   private final Producer<EncodedImage> mInputProducer;
-  private final @EnhancedTranscodingType int mEnhancedTranscodingType;
+  /* PACKAGE */ final @EnhancedTranscodingType int mEnhancedTranscodingType;
 
   public WebpTranscodeProducer(
       Executor executor,
@@ -108,7 +108,7 @@ public class WebpTranscodeProducer implements Producer<EncodedImage> {
     }
   }
 
-  private void transcodeLastResult(
+  /* PACKAGE */ void transcodeLastResult(
       final EncodedImage originalResult,
       final Consumer<EncodedImage> consumer,
       final ProducerContext producerContext) {
@@ -165,7 +165,7 @@ public class WebpTranscodeProducer implements Producer<EncodedImage> {
     mExecutor.execute(runnable);
   }
 
-  private static TriState shouldTranscode(final EncodedImage encodedImage) {
+  /* PACKAGE */ static TriState shouldTranscode(final EncodedImage encodedImage) {
     Preconditions.checkNotNull(encodedImage);
     ImageFormat imageFormat = ImageFormatChecker.getImageFormat_WrapIOException(
         encodedImage.getInputStream());
@@ -185,7 +185,7 @@ public class WebpTranscodeProducer implements Producer<EncodedImage> {
     return TriState.NO;
   }
 
-  private static void doTranscode(
+  /* PACKAGE */ static void doTranscode(
       final EncodedImage encodedImage,
       final PooledByteBufferOutputStream outputStream,
       final @EnhancedTranscodingType int enhancedWebpTranscodingType) throws Exception {


### PR DESCRIPTION
Fresco is creating a lot of synthetic methods everywhere. Im changing to package access all the ones I found across the dependencies I use daily.

This dependencies are:
- Drawee
- Drawee-pipeline
- Drawee-backends & Imagepipeline-backends (they were empty lol)
- ImagePipeline
- ImagePipeline-OkHttp3
- ImagePipeline-OkHttp

It would be really great to keep this into mind for future code, since in android we have the limitation of the 64k methods dex, and believe it or not, its really easy to reach them :)

You can see them easier with the j2re lint if using android studio =)
