### PR TITLE
Fixes FIT_CENTER ScaleType example

### DIFF
--- a/_docs/01-scaling.md
+++ b/_docs/01-scaling.md
@@ -85,12 +85,12 @@ In order to center the image we need to translate it a bit more. We can see that
 Congratulations! You just implemented the `FIT_CENTER` scale type:
 
 ```java
-  public static abstract class AbstractScaleType implements ScaleType {
+  public class AbstractScaleType implements ScaleType {
     @Override
     public Matrix getTransform(Matrix outTransform, Rect parentRect, int childWidth, int childHeight, float focusX, float focusY) {
       // calculate scale; we take the smaller of the horizontal and vertical scale factor so that the image always fits
-      final float sX = (float) parentRect.width() / (float) childWidth;
-      final float sY = (float) parentRect.height() / (float) childHeight;
+      final float scaleX = (float) parentRect.width() / (float) childWidth;
+      final float scaleY = (float) parentRect.height() / (float) childHeight;
       float scale = Math.min(scaleX, scaleY);
       
       // calculate translation; we offset by parent bounds, and by half of the empty space


### PR DESCRIPTION
In the custom ScaleType example the variables scaleX and scaleY where defined as sX and sY, but used as scaleY and scaleX.  Also the class was declared as `static abstract`, which is not possible. This pull request fixes the example.