### PR TITLE
Fix force rotation

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/RotationOptions.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/RotationOptions.java
@@ -39,7 +39,8 @@ public class RotationOptions {
       ROTATE_90,
       ROTATE_180,
       ROTATE_270,
-      USE_EXIF_ROTATION_ANGLE
+      USE_EXIF_ROTATION_ANGLE,
+      DISABLE_ROTATION
   })
   @Retention(RetentionPolicy.SOURCE)
   private @interface Rotation {}
@@ -58,6 +59,7 @@ public class RotationOptions {
   public static final int ROTATE_180 = 180;
   public static final int ROTATE_270 = 270;
   private static final int USE_EXIF_ROTATION_ANGLE = -1;
+  private static final int DISABLE_ROTATION = -2;
 
   private final @Rotation int mRotation;
   private final boolean mDeferUntilRendered;
@@ -73,6 +75,14 @@ public class RotationOptions {
    */
   public static RotationOptions autoRotate() {
     return new RotationOptions(USE_EXIF_ROTATION_ANGLE, false);
+  }
+
+  /**
+   * Creates a new set of rotation options for JPEG images to load image without any rotation.
+   *
+   */
+  public static RotationOptions disableRotation() {
+    return new RotationOptions(DISABLE_ROTATION, false);
   }
 
   /**
@@ -103,6 +113,10 @@ public class RotationOptions {
 
   public boolean useImageMetadata() {
     return mRotation == USE_EXIF_ROTATION_ANGLE;
+  }
+
+  public boolean rotationEnabled() {
+    return mRotation != DISABLE_ROTATION;
   }
 
   /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -292,11 +292,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
     if (rotationOptions.useImageMetadata()) {
       return rotationFromMetadata;
     }
-    int angle = rotationFromMetadata + rotationOptions.getForcedAngle();
-    while (angle >= FULL_ROUND) {
-      angle -= FULL_ROUND;
-    }
-    return angle;
+    return (rotationFromMetadata + rotationOptions.getForcedAngle()) % FULL_ROUND;
   }
 
   private static int extractOrientationFromMetadata(EncodedImage encodedImage) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -46,6 +46,7 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
   private static final String ORIGINAL_SIZE_KEY = "Original size";
   private static final String REQUESTED_SIZE_KEY = "Requested size";
   private static final String FRACTION_KEY = "Fraction";
+  private static final int FULL_ROUND = 360;
 
   @VisibleForTesting static final int DEFAULT_JPEG_QUALITY = 85;
   @VisibleForTesting static final int MAX_JPEG_SCALE_NUMERATOR = JpegTranscoder.SCALE_DENOMINATOR;
@@ -284,13 +285,16 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
   }
 
   private static int getRotationAngle(RotationOptions rotationOptions, EncodedImage encodedImage) {
+    if (!rotationOptions.rotationEnabled()) {
+      return RotationOptions.NO_ROTATION;
+    }
     int rotationFromMetadata = extractOrientationFromMetadata(encodedImage);
     if (rotationOptions.useImageMetadata()) {
       return rotationFromMetadata;
     }
     int angle = rotationFromMetadata + rotationOptions.getForcedAngle();
-    while (angle >= 360) {
-      angle -= 360;
+    while (angle >= FULL_ROUND) {
+      angle -= FULL_ROUND;
     }
     return angle;
   }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducer.java
@@ -284,18 +284,26 @@ public class ResizeAndRotateProducer implements Producer<EncodedImage> {
   }
 
   private static int getRotationAngle(RotationOptions rotationOptions, EncodedImage encodedImage) {
+    int rotationFromMetadata = extractOrientationFromMetadata(encodedImage);
     if (rotationOptions.useImageMetadata()) {
-      int rotationAngle = encodedImage.getRotationAngle();
-      switch (rotationAngle) {
-        case RotationOptions.ROTATE_90:
-        case RotationOptions.ROTATE_180:
-        case RotationOptions.ROTATE_270:
-          return rotationAngle;
-        default:
-          return 0;
-      }
+      return rotationFromMetadata;
     }
-    return rotationOptions.getForcedAngle();
+    int angle = rotationFromMetadata + rotationOptions.getForcedAngle();
+    while (angle >= 360) {
+      angle -= 360;
+    }
+    return angle;
+  }
+
+  private static int extractOrientationFromMetadata(EncodedImage encodedImage) {
+    switch (encodedImage.getRotationAngle()) {
+      case RotationOptions.ROTATE_90:
+      case RotationOptions.ROTATE_180:
+      case RotationOptions.ROTATE_270:
+        return encodedImage.getRotationAngle();
+      default:
+        return 0;
+    }
   }
 
   private static boolean shouldResize(int numerator) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequestBuilder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequestBuilder.java
@@ -157,7 +157,7 @@ public class ImageRequestBuilder {
     if (enabled) {
       return setRotationOptions(RotationOptions.autoRotate());
     } else {
-      return setRotationOptions(RotationOptions.forceRotation(RotationOptions.NO_ROTATION));
+      return setRotationOptions(RotationOptions.disableRotation());
     }
   }
 

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
@@ -167,8 +167,31 @@ public class ResizeAndRotateProducerTest {
   }
 
   @Test
-  public void testDoesNotTransformIfNotRequested() {
+  public void testDoesNotTransformIfRotationDisabled() {
     whenResizingEnabled();
+    whenDisableRotation();
+
+    provideIntermediateResult(DefaultImageFormats.JPEG);
+    verifyIntermediateResultPassedThroughUnchanged();
+
+    provideFinalResult(DefaultImageFormats.JPEG);
+    verifyFinalResultPassedThroughUnchanged();
+    verifyZeroJpegTranscoderInteractions();
+  }
+
+  @Test
+  public void testDoesNotTransformIfMetadataAngleAndRequestedRotationHaveOppositeValues() {
+    whenResizingEnabled();
+    whenRequestSpecificRotation(RotationOptions.ROTATE_270);
+
+    provideFinalResult(DefaultImageFormats.JPEG, 400, 200, 90);
+    verifyFinalResultPassedThroughUnchanged();
+    verifyZeroJpegTranscoderInteractions();
+  }
+
+  @Test
+  public void testDoesNotTransformIfNotRequested() {
+    whenResizingDisabled();
     whenRequestsRotationFromMetadataWithoutDeferring();
 
     provideIntermediateResult(DefaultImageFormats.JPEG);
@@ -405,9 +428,9 @@ public class ResizeAndRotateProducerTest {
   public void testDoesNothingWhenNotAskedToDoAnything() {
     whenResizingEnabled();
     whenRequestWidthAndHeight(0, 0);
-    whenRequestSpecificRotation(RotationOptions.NO_ROTATION);
+    whenDisableRotation();
 
-    provideFinalResult(DefaultImageFormats.JPEG, 400, 200, 0);
+    provideFinalResult(DefaultImageFormats.JPEG, 400, 200, 90);
     verifyAFinalResultPassedThrough();
     verifyZeroJpegTranscoderInteractions();
   }
@@ -565,6 +588,11 @@ public class ResizeAndRotateProducerTest {
       @RotationOptions.RotationAngle int rotationAngle) {
     when(mImageRequest.getRotationOptions())
         .thenReturn(RotationOptions.forceRotation(rotationAngle));
+  }
+
+  private void whenDisableRotation() {
+    when(mImageRequest.getRotationOptions())
+        .thenReturn(RotationOptions.disableRotation());
   }
 
   private void whenRequestsRotationFromMetadataWithDeferringAllowed() {

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/ResizeAndRotateProducerTest.java
@@ -407,7 +407,7 @@ public class ResizeAndRotateProducerTest {
     whenRequestWidthAndHeight(0, 0);
     whenRequestSpecificRotation(RotationOptions.NO_ROTATION);
 
-    provideFinalResult(DefaultImageFormats.JPEG, 400, 200, 90);
+    provideFinalResult(DefaultImageFormats.JPEG, 400, 200, 0);
     verifyAFinalResultPassedThrough();
     verifyZeroJpegTranscoderInteractions();
   }


### PR DESCRIPTION
This PR referrs #1492 
Rotation angle in `ResizeAndRotateProducer` now is computing according to image metadata. It's for rotating image from it's natural orientation.
Add `RotationOprtions.disableRotation()` to disable rotation. Previously it could be done via `RotationOptions.forceRotation(NO_ROTATION)`