### PR TITLE
Add largeHeap flag support.

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import android.app.ActivityManager;
 import android.content.Context;
 import android.graphics.Bitmap;
 
@@ -114,8 +113,7 @@ public class ImagePipelineConfig {
     mAnimatedImageFactory = builder.mAnimatedImageFactory;
     mBitmapMemoryCacheParamsSupplier =
         builder.mBitmapMemoryCacheParamsSupplier == null ?
-            new DefaultBitmapMemoryCacheParamsSupplier(
-                (ActivityManager) builder.mContext.getSystemService(Context.ACTIVITY_SERVICE)) :
+            new DefaultBitmapMemoryCacheParamsSupplier(builder.mContext) :
             builder.mBitmapMemoryCacheParamsSupplier;
     mBitmapConfig =
         builder.mBitmapConfig == null ?


### PR DESCRIPTION
Summary:
Many applications using largeHeap flag, fresco should obtain more memory for cache in this case.
