### PR TITLE
Update 02-using-image-pipeline.md

### DIFF
--- a/_docs/02-using-image-pipeline.md
+++ b/_docs/02-using-image-pipeline.md
@@ -100,4 +100,6 @@ Closing a prefetch data source after the prefetch has already completed is a no-
 
 As we can see, most of the `ImagePipeline` fetch methods contains a second parameter named `callerContext` of type `Object`. We can see it as an implementation of the [Context Object Design Pattern](https://www.dre.vanderbilt.edu/~schmidt/PDF/Context-Object-Pattern.pdf). It's basically an object we bind to a specific `ImageRequest` that can be used for different purposes (e.g. Log). The same object can also be accessed by all the `Producer` implementations into the `ImagePipeline`.
 
+The caller Context can also be `null`.
+
 


### PR DESCRIPTION
As mentioned in this [SO post](http://stackoverflow.com/questions/32830745/what-should-callercontext-param-be-for-frescos-prefetchtobitmapcache), the caller Context is allowed to be null.