### PR TITLE
Expose access to GIF's transparent's pixel

### DIFF
--- a/animated-gif/src/main/java/com/facebook/animated/gif/GifFrame.java
+++ b/animated-gif/src/main/java/com/facebook/animated/gif/GifFrame.java
@@ -81,6 +81,10 @@ public class GifFrame implements AnimatedImageFrame {
     return nativeHasTransparency();
   }
 
+  public int getTransparentPixel() {
+    return nativeGetTransparentPixel();
+  }
+
   public int getDisposalMode() {
     return nativeGetDisposalMode();
   }
@@ -92,6 +96,7 @@ public class GifFrame implements AnimatedImageFrame {
   private native int nativeGetXOffset();
   private native int nativeGetYOffset();
   private native int nativeGetDisposalMode();
+  private native int nativeGetTransparentPixel();
   private native boolean nativeHasTransparency();
   private native void nativeDispose();
   private native void nativeFinalize();

--- a/animated-gif/src/main/java/com/facebook/animated/gif/GifFrame.java
+++ b/animated-gif/src/main/java/com/facebook/animated/gif/GifFrame.java
@@ -81,8 +81,8 @@ public class GifFrame implements AnimatedImageFrame {
     return nativeHasTransparency();
   }
 
-  public int getTransparentPixel() {
-    return nativeGetTransparentPixel();
+  public int getTransparentPixelColor() {
+    return nativeGetTransparentPixelColor();
   }
 
   public int getDisposalMode() {
@@ -96,7 +96,7 @@ public class GifFrame implements AnimatedImageFrame {
   private native int nativeGetXOffset();
   private native int nativeGetYOffset();
   private native int nativeGetDisposalMode();
-  private native int nativeGetTransparentPixel();
+  private native int nativeGetTransparentPixelColor();
   private native boolean nativeHasTransparency();
   private native void nativeDispose();
   private native void nativeFinalize();


### PR DESCRIPTION
This is to address issue #1567, by allowing the consumer of this library to access the transparent color of a GIF image.