### PR TITLE
#1413: Remove incorrect cached data from caches.

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/cache/BufferedDiskCache.java
@@ -187,6 +187,11 @@ public class BufferedDiskCache {
                   try {
                     result = new EncodedImage(ref);
                     result.setEncodedCacheKey(key);
+                  } catch (Exception e) {
+                    // Remove the cached data if it cannot be used to create an encoded image.
+                    CloseableReference.closeSafely(ref);
+                    remove(key);
+                    throw e;
                   } finally {
                     CloseableReference.closeSafely(ref);
                   }


### PR DESCRIPTION
I'm not convinced by this change, and would welcome any feedback.

I think that this solution should fix the problem, but would require the library to load the image twice before both caches are cleared. The caches don't talk to each other at the moment, so I'm not sure how to solve that.

This change would also require tests (but I want to get feedback on what I've changed first in case I'm barking up the wrong tree).