### PR TITLE
Fix WebpBitmapFactoryImpl.createBitmap() being called with wrong class

### DIFF
--- a/static-webp/src/main/jni/static-webp/webp_bitmapfactory.cpp
+++ b/static-webp/src/main/jni/static-webp/webp_bitmapfactory.cpp
@@ -95,7 +95,7 @@ static void setBitmapSize(JNIEnv* env, jobject bitmapOptions, int image_width, i
 }
 
 static jobject createBitmap(JNIEnv* env, int image_width, int image_height, jobject bitmapOptions) {
-  jobject bitmap = env->CallStaticObjectMethod(bitmapClass, createBitmapFunction, image_width, image_height, bitmapOptions);
+  jobject bitmap = env->CallStaticObjectMethod(webpBitmapFactoryClass, createBitmapFunction, image_width, image_height, bitmapOptions);
   return bitmap;
 }
 


### PR DESCRIPTION
When JNI debugging is enabled, ART is very pedantic about what class you are passing when invoking static method. In this case, this is causing a crash:

runtime.cc:476] JNI DETECTED ERROR IN APPLICATION: can't call static android.graphics.Bitmap com.facebook.webpsupport.WebpBitmapFactoryImpl.createBitmap(int, int, android.graphics.BitmapFactory$Options) with class java.lang.Class<android.graphics.Bitmap>
runtime.cc:476]     in call to CallStaticObjectMethodV
runtime.cc:476]     from android.graphics.Bitmap com.facebook.webpsupport.WebpBitmapFactoryImpl.nativeDecodeByteArray(byte[], int, int, android.graphics.BitmapFactory$Options, float, byte[])