### PR TITLE
Remove explicit, although empty, baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,6 @@
 ---
 permalink: /blog/:categories/:year/:month/:day/:title.html
 url: "http://frescolib.org"
-baseurl: ""
 title: Fresco
 tagline: An Image Management Library
 fbappid: "1615782811974223"


### PR DESCRIPTION
We are running into problem with bot-commits again like we did with Nuclide. bot-commits are causing problems with GitHub pages, appending baseurls when there should not be any.
Let's remove it from the config and see if that fixes the issue for now.