### PR TITLE
Jekyll Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,5 @@ local.properties
 localhost/
 obj/
 *.iml
-Gemfile
 Gemfile.lock
 _site/
-

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,6 @@
 .DS_STORE
 _site/
 *-e
-Gemfile
 Gemfile.lock
 *.swo
 *.swp

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', '~> 104', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,6 +10,7 @@ description: >
   Fresco is a powerful system for displaying images in Android applications. It takes care of image loading and display so you don’t have to. Fresco supports Android 2.3 (Gingerbread) and later.
 timezone: America/Los_Angeles
 ghrepo: "facebook/fresco"
+logo: /static/logo.png
 
 current_version: 1.0.0
 
@@ -46,3 +47,17 @@ color:
   # or 'dark'
   primary-overlay: "dark"
   secondary-overlay: "light"
+
+# Gems
+gems:
+  - jekyll-feed
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Set default open graph image for all pages
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      image: /static/og_image.png

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -1,17 +1,17 @@
 - title: Docs
-  href: http://frescolib.org/docs/
+  href: /docs/
   category: docs
 
 - title: Support
-  href: http://frescolib.org/support.html
+  href: /support.html
   category: support
 
 - title: Blog
-  href: http://frescolib.org/blog/
+  href: /blog/
   category: posts
 
 - title: API
-  href: http://frescolib.org/javadoc/
+  href: /javadoc/
   category: apidocs
 
 - title: GitHub

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,21 +3,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
-  <meta property="og:site_name" content="{{ site.title }}"/>
-  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
-  <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/static/og_image.png" />
-  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
+  {% seo %}
 
   <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css" media="screen">
   <link rel="icon" href="{{ site.url }}{{ site.baseurl }}/static/favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
 
   <script src="http://fb.me/react-with-addons-0.13.1.min.js"></script>
-
-  <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 </head>


### PR DESCRIPTION
- Add Gemfile to allow easy running of site locally
- Use new seo plugin for og info
- Use feed plugin for the XML feed
- Use relative URLs for local-to-site links in nav bar (makes it easier for local testing too)

See https://github.com/facebook/nuclide/pull/952 where some of this was provided for Nuclide by a GitHub team member

Tested by running site locally.