### PR TITLE
Use feed plugin

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -10,4 +10,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
 
   <script src="http://fb.me/react-with-addons-0.13.1.min.js"></script>
+
+  {% comment %}
+  For our RSS feed.xml
+  https://help.github.com/articles/atom-rss-feeds-for-github-pages/
+  {% endcomment %}
+  {% feed_meta %}
 </head>


### PR DESCRIPTION
I removed the manual feed in https://github.com/facebook/fresco/commit/47be75313d8b8b1c203595d752c37a27a4e24c65
but forgot the plugin to replace it