### PR TITLE
Use BufferType.SPANNABLE in setText of SimpleDraweeSpanStringBuilder

### DIFF
--- a/drawee-span/src/main/java/com/facebook/drawee/span/SimpleDraweeSpanTextView.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/SimpleDraweeSpanTextView.java
@@ -88,7 +88,7 @@ public class SimpleDraweeSpanTextView extends TextView {
   public void setDraweeSpanStringBuilder(DraweeSpanStringBuilder draweeSpanStringBuilder) {
     // setText will trigger onTextChanged, which will clean up the old draweeSpanStringBuilder
     // if necessary
-    setText(draweeSpanStringBuilder);
+    setText(draweeSpanStringBuilder, BufferType.SPANNABLE);
     mDraweeStringBuilder = draweeSpanStringBuilder;
     if (mDraweeStringBuilder != null && mIsAttached) {
       mDraweeStringBuilder.onAttachToView(this);


### PR DESCRIPTION
Explicitly uses `BufferType.SPANNABLE` to let `SimpleDraweeSpanTextView` know that it might need to resize itself. See associated issue: https://github.com/facebook/fresco/issues/1633

Feel free to suggest alternative solutions; I think this is safe to do and a cursory search didn't turn up anything better, but I suspect maintainers of `DraweeSpan` might know more about spans than I do!