### PR TITLE
Improve error handling for okhttp

### DIFF
--- a/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp/src/main/java/com/facebook/imagepipeline/backends/okhttp/OkHttpNetworkFetcher.java
@@ -80,19 +80,24 @@ public class OkHttpNetworkFetcher extends
   public void fetch(final OkHttpNetworkFetchState fetchState, final Callback callback) {
     fetchState.submitTime = SystemClock.uptimeMillis();
     final Uri uri = fetchState.getUri();
-    final Request request;
 
     try {
-     request = new Request.Builder()
+      Request request = new Request.Builder()
         .cacheControl(new CacheControl.Builder().noStore().build())
         .url(uri.toString())
         .get()
         .build();
+      fetchWithRequest(fetchState, callback, request);
     } catch (Exception e) {
-      // handle malformed Uri
+      // handle error while creating the request
       callback.onFailure(e);
-      return;
     }
+  }
+
+  protected void fetchWithRequest(
+          final OkHttpNetworkFetchState fetchState,
+          final Callback callback,
+          final Request request) {
 
     final Call call = mOkHttpClient.newCall(request);
 

--- a/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
@@ -86,12 +86,19 @@ public class OkHttpNetworkFetcher extends
   public void fetch(final OkHttpNetworkFetchState fetchState, final Callback callback) {
     fetchState.submitTime = SystemClock.elapsedRealtime();
     final Uri uri = fetchState.getUri();
-    final Request request = new Request.Builder()
+
+    try {
+      Request request = new Request.Builder()
         .cacheControl(new CacheControl.Builder().noStore().build())
         .url(uri.toString())
         .get()
         .build();
-    fetchWithRequest(fetchState, callback, request);
+
+      fetchWithRequest(fetchState, callback, request);
+    } catch (Exception e) {
+      // handle error while creating the request
+      callback.onFailure(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
PR for issue #1513 

I added the fetchWithRequest() method inside Okhttp2 fetcher to make the implementation more consistent.