### PR TITLE
fix duplicate media variant entries

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/MediaVariationsIndexDatabase.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/MediaVariationsIndexDatabase.java
@@ -35,6 +35,7 @@ import com.facebook.imagepipeline.request.MediaVariations;
 import bolts.Task;
 
 public class MediaVariationsIndexDatabase implements MediaVariationsIndex {
+
   private static final String TAG = MediaVariationsIndexDatabase.class.getSimpleName();
 
   private static final String[] PROJECTION = {
@@ -146,7 +147,7 @@ public class MediaVariationsIndexDatabase implements MediaVariationsIndex {
             contentValues
                 .put(IndexEntry.COLUMN_NAME_RESOURCE_ID, CacheKeyUtil.getFirstResourceId(cacheKey));
 
-            db.insertOrThrow(IndexEntry.TABLE_NAME, null, contentValues);
+            db.replaceOrThrow(IndexEntry.TABLE_NAME, null, contentValues);
 
             db.setTransactionSuccessful();
           } catch (Exception x) {
@@ -170,6 +171,7 @@ public class MediaVariationsIndexDatabase implements MediaVariationsIndex {
   }
 
   private static class LazyIndexDbOpenHelper {
+
     private final Context mContext;
     private @Nullable IndexDbOpenHelper mIndexDbOpenHelper;
 
@@ -187,6 +189,8 @@ public class MediaVariationsIndexDatabase implements MediaVariationsIndex {
 
   private static class IndexDbOpenHelper extends SQLiteOpenHelper {
 
+    public static final int DATABASE_VERSION = 1;
+    public static final String DATABASE_NAME = "FrescoMediaVariationsIndex.db";
     private static final String TEXT_TYPE = " TEXT";
     private static final String INTEGER_TYPE = " INTEGER";
     private static final String SQL_CREATE_ENTRIES =
@@ -196,13 +200,10 @@ public class MediaVariationsIndexDatabase implements MediaVariationsIndex {
             IndexEntry.COLUMN_NAME_WIDTH + INTEGER_TYPE + "," +
             IndexEntry.COLUMN_NAME_HEIGHT + INTEGER_TYPE + "," +
             IndexEntry.COLUMN_NAME_CACHE_KEY + TEXT_TYPE + "," +
-            IndexEntry.COLUMN_NAME_RESOURCE_ID + TEXT_TYPE + " )";
+            IndexEntry.COLUMN_NAME_RESOURCE_ID + TEXT_TYPE + " UNIQUE )";
     private static final String SQL_CREATE_INDEX =
         "CREATE INDEX index_media_id ON " + IndexEntry.TABLE_NAME + " (" +
             IndexEntry.COLUMN_NAME_MEDIA_ID + ")";
-
-    public static final int DATABASE_VERSION = 1;
-    public static final String DATABASE_NAME = "FrescoMediaVariationsIndex.db";
 
     public IndexDbOpenHelper(Context context) {
       super(context, DATABASE_NAME, null, DATABASE_VERSION);


### PR DESCRIPTION
**motivation** :
when I download some images with media variations feature enabled, then I got some entries written to the media variations index database, but if I cleared all the previous cached  images (or load the same image while writing index info to the db) , and reload those images again, I would got duplicate entries with the same mediaId, width, height and resourceId pointing to the same disk cache key
   
**reproduce steps** :
0. check out current master branch
1.  just run example/media-variations
2. click to load all the images
3. then click the "Clear cache and reset" menu
4. reload all those images again
5. repeat step 3 and 4 if you want
6. pull the media-variations index database from the test device, open it using a sqlite3 client and query all entries from media_variations_index table
7. ***observable result*** : you would find more than one entries with identical mediaId, width, height, resourceId, cache_key and resource_id (except the auto generated primary key)

**Test plan**
execute the reproduce steps based on this pr,
check out if there any duplicates entries, if no two entries are identical then the issue is fixes.