### PR TITLE
fix stream res leak

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
@@ -10,6 +10,7 @@
 package com.facebook.imagepipeline.producers;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Locale;
@@ -75,16 +76,23 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
   @VisibleForTesting
   void fetchSync(FetchState fetchState, Callback callback) {
     HttpURLConnection connection = null;
-
+    InputStream is = null;
     try {
       connection = downloadFrom(fetchState.getUri(), MAX_REDIRECTS);
 
       if (connection != null) {
-        callback.onResponse(connection.getInputStream(), -1);
+        is = connection.getInputStream();
+        callback.onResponse(is, -1);
       }
     } catch (IOException e) {
       callback.onFailure(e);
     } finally {
+      if (is != null) {
+        try {
+          is.close();
+        } catch (IOException e) {
+        }
+      }
       if (connection != null) {
         connection.disconnect();
       }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
@@ -91,6 +91,7 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
         try {
           is.close();
         } catch (IOException e) {
+          //Do nothing and ignore the IOException here.
         }
       }
       if (connection != null) {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Prefer **small pull requests**. These are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

**Test plan (required)**
Please clone the demo from :https://github.com/caojianfeng/FrescoDemo.git
And run it.
Now it will crash when started or scroll the image list.
And My test device is Android 4.1.2 .I receive this:

```
03-07 01:16:27.343 18562-18571/caojianfeng.frescodemo E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
                                                                    java.lang.Throwable: Explicit termination method 'end' not called
                                                                        at dalvik.system.CloseGuard.open(CloseGuard.java:184)
                                                                        at java.util.zip.Inflater.<init>(Inflater.java:82)
                                                                        at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:96)
                                                                        at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:81)
                                                                        at libcore.net.http.HttpEngine.initContentStream(HttpEngine.java:528)
                                                                        at libcore.net.http.HttpEngine.readResponse(HttpEngine.java:836)
                                                                        at libcore.net.http.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:274)
                                                                        at libcore.net.http.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:486)
                                                                        at com.facebook.imagepipeline.producers.HttpUrlConnectionNetworkFetcher.downloadFrom(HttpUrlConnectionNetworkFetcher.java:97)
                                                                        at com.facebook.imagepipeline.producers.HttpUrlConnectionNetworkFetcher.fetchSync(HttpUrlConnectionNetworkFetcher.java:80)
                                                                        at com.facebook.imagepipeline.producers.HttpUrlConnectionNetworkFetcher$1.run(HttpUrlConnectionNetworkFetcher.java:61)
                                                                        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:442)
                                                                        at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:305)
                                                                        at java.util.concurrent.FutureTask.run(FutureTask.java:137)
                                                                        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
                                                                        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
                                                                        at java.lang.Thread.run(Thread.java:856)

```
When the fixed Lib work . It will show a image list and can be scroll to the bottom of the list.


Make sure tests pass on Circle CI.

**Code formatting**

Look around. Match the style of the rest of the codebase. See also the simple [style guide](https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md#coding-style). If you use IntelliJ IDEA or Android Studio, it should automatically pick up the [code style settings](https://github.com/facebook/fresco/blob/master/.idea/codeStyleSettings.xml).

For more info, see the ["Pull Requests" section of our "Contributing" guidelines](https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md#pull-requests).
