### PR TITLE
Fix two links

### DIFF
--- a/docs/_docs/02-datasources-datasubscribers.md
+++ b/docs/_docs/02-datasources-datasubscribers.md
@@ -14,11 +14,11 @@ After submitting an image request, the image pipeline returns a data source. To 
 ### Executors
 
 When subscribing to a data source, an executor must be provided. The purpose of executors is to execute runnables (in our case the subscriber callback methods) on a specific thread and with specific policy.
-Fresco provides several [executors] (https://github.com/facebook/fresco/tree/0f3d52318631f2125e080d2a19f6fa13a31efb31/fbcore/src/main/java/com/facebook/common/executors) and one should carefully choose which one to be used:
+Fresco provides several [executors](https://github.com/facebook/fresco/tree/0f3d52318631f2125e080d2a19f6fa13a31efb31/fbcore/src/main/java/com/facebook/common/executors) and one should carefully choose which one to be used:
 
 * If you need to do any UI stuff from your callback (accessing views, drawables, etc.), you must use `UiThreadImmediateExecutorService.getInstance()`. Android view system is not thread safe and is only to be accessed from the main thread (the UI thread).
 * If the callback is lightweight, and does not do any UI related stuff, you can simply use `CallerThreadExecutor.getInstance()`. This executor executes runnables on the caller's thread. Depending on what is the calling thread, callback may be executed either on the UI or a background thread. There are no guarantees which thread it is going to be and because of that this executor should be used with great caution. And again, only for lightweight non-UI related stuff.
-* If you need to do some expensive non-UI related work (database access, disk read/write, or any other slow operation), this should NOT be done either with `CallerThreadExecutor` nor with the `UiThreadExecutorService`, but with one of the background thread executors. See [DefaultExecutorSupplier.forBackgroundTasks] (https://github.com/facebook/fresco/blob/0f3d52318631f2125e080d2a19f6fa13a31efb31/imagepipeline/src/main/java/com/facebook/imagepipeline/core/DefaultExecutorSupplier.java) for an example implementation.
+* If you need to do some expensive non-UI related work (database access, disk read/write, or any other slow operation), this should NOT be done either with `CallerThreadExecutor` nor with the `UiThreadExecutorService`, but with one of the background thread executors. See [DefaultExecutorSupplier.forBackgroundTasks](https://github.com/facebook/fresco/blob/0f3d52318631f2125e080d2a19f6fa13a31efb31/imagepipeline/src/main/java/com/facebook/imagepipeline/core/DefaultExecutorSupplier.java) for an example implementation.
 
 ### Getting result from a data source
 


### PR DESCRIPTION
Extra spaces are likely causing the links to be rendered incorrectly on the main docs site (GH is more lenient).

![datasources_and_datasubscribers_-_fresco](https://cloud.githubusercontent.com/assets/90963/23646968/ba3fb6f0-0313-11e7-8125-d2c328ffd9b8.png)
