### PR TITLE
[samples] Add support for Stetho's dumpapp tool to the Fresco showcase app

### DIFF
--- a/samples/showcase/build.gradle
+++ b/samples/showcase/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile "com.android.support:preference-v7:${SUPPORT_LIB_VERSION}"
     compile "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
     compile "com.android.support:cardview-v7:${SUPPORT_LIB_VERSION}"
+    compile "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"
 
     compile 'com.facebook.keyframes:keyframes:1.0'
 
@@ -54,6 +55,7 @@ dependencies {
 
     compile project(':drawee-backends:drawee-pipeline')
     compile project(':drawee-span')
+    compile project(':tools:stetho')
 
     // Only used for the custom SVG decoder
     compile 'com.caverock:androidsvg:1.2.1'

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import android.app.Application;
+import android.content.Context;
 
 import com.facebook.common.internal.Supplier;
 import com.facebook.common.logging.FLog;
@@ -25,6 +26,10 @@ import com.facebook.fresco.samples.showcase.misc.DebugOverlaySupplierSingleton;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.imagepipeline.listener.RequestListener;
 import com.facebook.imagepipeline.listener.RequestLoggingListener;
+import com.facebook.imagepipeline.stetho.FrescoStethoPlugin;
+import com.facebook.stetho.DumperPluginsProvider;
+import com.facebook.stetho.Stetho;
+import com.facebook.stetho.dumpapp.DumperPlugin;
 
 /**
  * Showcase Application implementation where we set up Fresco
@@ -57,5 +62,17 @@ public class ShowcaseApplication extends Application {
         DebugOverlaySupplierSingleton.getInstance(getApplicationContext()));
 
     Fresco.initialize(this, imagePipelineConfig, draweeConfigBuilder.build());
+
+    final Context context = this;
+    Stetho.initialize(Stetho.newInitializerBuilder(context)
+        .enableDumpapp(new DumperPluginsProvider() {
+          @Override
+          public Iterable<DumperPlugin> get() {
+            return new Stetho.DefaultDumperPluginsBuilder(context)
+                .provide(new FrescoStethoPlugin())
+                .finish();
+          }
+        })
+        .build());
   }
 }


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch

## Motivation (required)

This allows us to use Stetho's dumpapp tool to inspect the Showcase app. The code is [copied from the Comparison app](https://github.com/facebook/fresco/blob/master/samples/comparison/src/main/java/com/facebook/samples/comparison/ComparisonApp.java#L29).

![screenshot 2017-04-11 11 07 04](https://cloud.githubusercontent.com/assets/346214/24904154/791531b4-1ea7-11e7-97f8-cd5db1cd52fd.png)

## Test Plan (required)

- Ran the Fresco Showcase app from Android Studio.
- Ran `./scripts/dumpapp image memcache` from Stetho's open source distribution.
- See the screenshot above.
- `./scripts/dumpapp image diskcache` works too:

<img width="1062" alt="screenshot 2017-04-11 11 12 55" src="https://cloud.githubusercontent.com/assets/346214/24904264/d477c210-1ea7-11e7-8f8c-033ba0cc77f0.png">
