### PR TITLE
[samples] Use more varied images in the RecyclerView sample

### DIFF
--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeRecyclerViewFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeRecyclerViewFragment.java
@@ -33,22 +33,27 @@ import com.facebook.fresco.samples.showcase.R;
 public class DraweeRecyclerViewFragment extends BaseShowcaseFragment {
 
   /**
-   * Total number of images displayed
+   * lorempixel.com image categories.
    */
-  private static final int TOTAL_NUM_ENTRIES = 200;
+  private static final String[] CATEGORIES = {
+     "animals",
+     "sports",
+     "nature",
+     "city",
+     "food",
+     "people",
+     "nightlife",
+     "fashion",
+     "transport",
+     "cats",
+     "business",
+     "technics",
+  };
 
   /**
-   * URIs that will be repeated
+   * How many images per each category.
    */
-  private static final Uri[] URIS = {
-      Uri.parse("http://frescolib.org/static/sample-images/animal_a_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_b_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_c_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_d_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_e_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_f_s.jpg"),
-      Uri.parse("http://frescolib.org/static/sample-images/animal_g_s.jpg"),
-  };
+  private static final int NUM_ENTRIES_PER_CATEGORY = 10;
 
   /**
    * Number of recycler view spans
@@ -79,14 +84,11 @@ public class DraweeRecyclerViewFragment extends BaseShowcaseFragment {
 
   private List<Uri> createDummyData() {
     List<Uri> data = new ArrayList<>();
-    for (int i = 0; i < TOTAL_NUM_ENTRIES; i++) {
-      // We add the URI and append a query parameter (?cache_busting=123) so that each image
-      // will be treated as a separate network image.
-      data.add(
-          URIS[i % URIS.length]
-              .buildUpon()
-              .appendQueryParameter("cache_busting", Integer.toString(i))
-              .build());
+    for (int i = 0; i < NUM_ENTRIES_PER_CATEGORY; i++) {
+      for (int j = 0; j < CATEGORIES.length; j++) {
+        data.add(Uri.parse(String.format(
+            "http://lorempixel.com/400/400/%s/%d", CATEGORIES[j], i + 1)));
+      }
     }
     return data;
   }


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [x] Target the `master` branch

## Motivation (required)

Currently the example has only a few images which makes it hard to visually debug what's in cache:

<img width="415" alt="screenshot 2017-04-12 14 09 40" src="https://cloud.githubusercontent.com/assets/346214/24959181/d33d72e0-1f89-11e7-921f-cec551c8bf47.png">

This PR makes the example a bit more realistic by using many different images (120 in total):

<img width="415" alt="screenshot 2017-04-12 13 53 44" src="https://cloud.githubusercontent.com/assets/346214/24959208/ec355e3e-1f89-11e7-81a4-58e4722679ce.png">

## Test Plan (required)

Ran the Showcase app from Android Studio, see the screenshot above.
