### PR TITLE
[DO NOT MERGE] Demo rounding using View.setClipToOutline(), available on API 21+

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
@@ -36,10 +36,15 @@ public class RoundingParams {
      * {@link ScalingUtils.ScaleType#CENTER_CROP}, {@link ScalingUtils.ScaleType#FOCUS_CROP} and
      * {@link ScalingUtils.ScaleType#FIT_XY}.
      */
-    BITMAP_ONLY
+    BITMAP_ONLY,
+
+    /**
+     * On Android versions >= 21 (Lollipop) uses the {@code View.setClipToOutline} method.
+     */
+    OUTLINE,
   }
 
-  private RoundingMethod mRoundingMethod = RoundingMethod.BITMAP_ONLY;
+  private RoundingMethod mRoundingMethod = RoundingMethod.OUTLINE;
   private boolean mRoundAsCircle = false;
   private float[] mCornersRadii = null;
   private int mOverlayColor = 0;


### PR DESCRIPTION
Shows how to use the API 21 method [`View.setOutlineProvider`](https://developer.android.com/reference/android/view/View.html#setOutlineProvider(android.view.ViewOutlineProvider)) to implement rounded corners.

This method supports circles, ellipses and round rectangles with uniform corner radius (documented [here](https://developer.android.com/reference/android/graphics/Outline.html#canClip()) and tried [here](http://stackoverflow.com/questions/43548063/android-view-outline-using-a-custom-path)).

Result (Fresco showcase app):

<img width="436" alt="screenshot 2017-04-24 13 55 25" src="https://cloud.githubusercontent.com/assets/346214/25338988/074b3fea-28f9-11e7-8752-78d53005e7c7.png">
