### PR TITLE
RFC: Clarify docs on limitations of the BITMAP_ONLY rounding method

### DIFF
--- a/docs/_docs/01-rounded-corners-and-circles.md
+++ b/docs/_docs/01-rounded-corners-and-circles.md
@@ -22,8 +22,8 @@ Rectangles support having each of the four corners have a different radius, but 
 
 Images can be rounded with two different methods:
 
-1. `BITMAP_ONLY` - Uses a bitmap shader to draw the bitmap with rounded corners. This is the default rounding method. It doesn't support animations, and it does **not** support any scale types other than `centerCrop` (the default), `focusCrop` and `fit_xy`.
-2. `OVERLAY_COLOR` - Draws rounded corners by overlaying a solid color, specified by the caller. The Drawee's background should be static and of the same solid color. Use `roundWithOverlayColor` in XML, or `setOverlayColor` in code, for this effect.
+1. `BITMAP_ONLY` - Uses a bitmap shader to draw the bitmap with rounded corners. This is the default rounding method. It doesn't support animations, and it does **not** support any scale types other than `centerCrop` (the default), `focusCrop` and `fit_xy`. If you use this rounding method with other scale types, such as 'center', you won't get an Exception but the image might look wrong (e.g. repeated edges due to how Android shaders work), especially in cases the source image is smaller than the view. See the Caveats section below.
+2. `OVERLAY_COLOR` - Draws rounded corners by overlaying a solid color, specified by the caller. The Drawee's background should be static and of the same solid color. Use `roundWithOverlayColor` in XML, or `setOverlayColor` in code to use this rounding method.
 
 ### In XML
 
@@ -71,7 +71,7 @@ There are some limitations when `BITMAP_ONLY` (the default) mode is used:
 - Animations are not rounded.
 - Due to a limitation of Android's `BitmapShader`, if the image doesn't fully cover the view, instead of drawing nothing, edges are repeated. One workaround is to use a different scale type (e.g. centerCrop) that ensures that the whole view is covered. Another workaround is to make the image file contain a 1px transparent border so that the transparent pixels get repeated. This is the best solution for PNG resource images.
 
-If the limitations of the `BITMAP_ONLY` mode affect your images, see if the `OVERLAY_COLOR` mode works for you. The `OVERLAY_COLOR` mode doesn't have the aforementioned limitations, but since it simulates rounded corners by overlying a solid color over the image, this only looks good if the background under the view is static and of the same color.
+If the limitations of the `BITMAP_ONLY` mode affect your images, see if the `OVERLAY_COLOR` mode works for you. The `OVERLAY_COLOR` mode doesn't have the aforementioned limitations, but since it simulates rounded corners by overlaying a solid color over the image, this only looks good if the background under the view is static and of the same color.
 
 Drawee internally has an implementation for `CLIPPING` mode, but this mode has been disabled and not exposed as some `Canvas` implementation do not support path clipping. Furthermore, canvas clipping doesn't support antialiasing which makes the rounded edges very pixelated.
 

--- a/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
@@ -35,6 +35,9 @@ public class RoundingParams {
      * method. It doesn't support animations, and it does not support any scale types other than
      * {@link ScalingUtils.ScaleType#CENTER_CROP}, {@link ScalingUtils.ScaleType#FOCUS_CROP} and
      * {@link ScalingUtils.ScaleType#FIT_XY}.
+     * If you use this rounding method with other scale types, such as
+     * {@link ScalingUtils.ScaleType#CENTER}, you won't get an Exception but the image might look
+     * wrong (e.g. repeated edges), especially in cases the source image is smaller than the view.
      */
     BITMAP_ONLY
   }


### PR DESCRIPTION
## Motivation

The docs state that using the `BITMAP_ONLY` rounding method with certain scale types is not supported. For example `BITMAP_ONLY` should not work with scale type `CENTER`.

I tried using this unsupported combination and expected this to not work. However, I didn't see an exception, and the image looked correct too. This was confusing, I thought the docs were outdated. I'm clarifying the docs a bit.

## Discussion - Please comment

Looking at the docs, we don't explain why someone would want to use one method over the other. We explain limitations of each method but don't explain *advantages*. As a user, how do I choose?

When should I use `BITMAP_ONLY`.  Does it have better performance?

Reading about the limitations of `BITMAP_ONLY` I might get worried it's too limited and just always use `OVERLAY_COLOR` in the common case there's a solid color background.

## Test plan

n/a - Docs only.