### PR TITLE
Add a new rounding method using View.setOutlineProvider

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
@@ -36,7 +36,12 @@ public class RoundingParams {
      * {@link ScalingUtils.ScaleType#CENTER_CROP}, {@link ScalingUtils.ScaleType#FOCUS_CROP} and
      * {@link ScalingUtils.ScaleType#FIT_XY}.
      */
-    BITMAP_ONLY
+    BITMAP_ONLY,
+
+    /**
+     * On Android versions >= 21 (Lollipop) uses the {@code View.setClipToOutline} method.
+     */
+    OUTLINE
   }
 
   private RoundingMethod mRoundingMethod = RoundingMethod.BITMAP_ONLY;

--- a/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/RoundingParams.java
@@ -40,6 +40,9 @@ public class RoundingParams {
 
     /**
      * On Android versions >= 21 (Lollipop) uses the {@code View.setClipToOutline} method.
+     * This method only supports uniform rounded corners - all 4 corners have the same radius,
+     * or the image forms a circle. If you want each corner to have a different radius
+     * use one of the other rounding methods.
      */
     OUTLINE
   }
@@ -117,6 +120,7 @@ public class RoundingParams {
 
   /**
    * Gets the rounded corners radii.
+   * The corners are ordered top-left, top-right, bottom-right, bottom-left.
    *
    * <p> For performance reasons the internal array is returned directly. Do not modify it directly,
    * but use one of the exposed corner radii setters instead.

--- a/drawee/src/main/java/com/facebook/drawee/generic/WrappingUtils.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/WrappingUtils.java
@@ -174,6 +174,8 @@ public class WrappingUtils {
    * its rounding parameters are updated.
    * <li>If rounding mode is not BITMAP_ONLY and the child is rounded,
    * its rounding parameters are reset so that no rounding occurs.
+   * <li>If rounding mode is OUTLINE no rounding happens here at the leaf drawable level.
+   * Instead rounding is done at the view level.
    * </ul>
    */
   static void updateLeafRounding(

--- a/drawee/src/main/java/com/facebook/drawee/view/GenericDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/GenericDraweeView.java
@@ -73,12 +73,15 @@ public class GenericDraweeView extends DraweeView<GenericDraweeHierarchy> {
     if (hasHierarchy()) {
       getHierarchy().setRoundingParams(roundingParams);
     }
-    if (Build.VERSION.SDK_INT >= 21 &&
-        roundingParams.getRoundingMethod() == RoundingParams.RoundingMethod.OUTLINE) {
-      if (roundingParams != null) {
+    if (Build.VERSION.SDK_INT >= 21) {
+      if (
+          roundingParams != null &&
+          roundingParams.getRoundingMethod() == RoundingParams.RoundingMethod.OUTLINE) {
         this.setClipToOutline(true);
         this.setOutlineProvider(getClipOutlineProvider());
       } else {
+        // If rounding method was outline and it's now set to something else than outline,
+        // don't forget to disable the clipping.
         this.setClipToOutline(false);
         this.setOutlineProvider(null);
       }

--- a/drawee/src/main/java/com/facebook/drawee/view/GenericDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/GenericDraweeView.java
@@ -13,12 +13,17 @@ import javax.annotation.Nullable;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.graphics.Outline;
 import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewOutlineProvider;
 
 import com.facebook.drawee.generic.GenericDraweeHierarchy;
 import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
 import com.facebook.drawee.generic.GenericDraweeHierarchyInflater;
+import com.facebook.drawee.generic.RoundingParams;
 
 /**
  * DraweeView that uses GenericDraweeHierarchy.
@@ -59,5 +64,75 @@ public class GenericDraweeView extends DraweeView<GenericDraweeHierarchy> {
         GenericDraweeHierarchyInflater.inflateBuilder(context, attrs);
     setAspectRatio(builder.getDesiredAspectRatio());
     setHierarchy(builder.build());
+  }
+
+  /**
+   * Sets the rounding params.
+   */
+  public void setRoundingParams(@Nullable RoundingParams roundingParams) {
+    if (hasHierarchy()) {
+      getHierarchy().setRoundingParams(roundingParams);
+    }
+    if (Build.VERSION.SDK_INT >= 21) {
+      if (roundingParams != null) {
+        this.setClipToOutline(true);
+        this.setOutlineProvider(getRoundedClipOutlineProvider());
+      } else {
+        this.setClipToOutline(false);
+        this.setOutlineProvider(null);
+      }
+    }
+  }
+
+  /**
+   * Gets the rounding params.
+   */
+  @Nullable
+  public RoundingParams getRoundingParams() {
+    if (hasHierarchy()) {
+      return getHierarchy().getRoundingParams();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Cached return value of {@link #getRoundedClipOutlineProvider}.
+   */
+  private static ViewOutlineProvider mRoundedClipOutlineProvider;
+
+  /**
+   * Creates an outline used for clipping the image so that it has rounded corners.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  private static ViewOutlineProvider getRoundedClipOutlineProvider() {
+    if (mRoundedClipOutlineProvider == null) {
+      mRoundedClipOutlineProvider = new ViewOutlineProvider() {
+        @Override
+        public void getOutline(View view, Outline outline) {
+          if (!(view instanceof GenericDraweeView)) {
+            throw new AssertionError(
+                "For rounded corners using the outline API, View must be a GenericDraweeView");
+          }
+          final GenericDraweeView dv = (GenericDraweeView) view;
+          RoundingParams roundingParams = dv.getHierarchy().getRoundingParams();
+          if (roundingParams.getRoundAsCircle()) {
+            int w = view.getWidth();
+            int h = view.getHeight();
+            if (w > h) {
+              int l = (w - h) / 2;
+              outline.setOval(l, 0, l + h, h);
+            } else {
+              int t = (h - w) / 2;
+              outline.setOval(0, t, w, t + w);
+            }
+          } else {
+            // TODO radius
+            outline.setRoundRect(0, 0, view.getWidth(), view.getHeight(), 16);
+          }
+        }
+      };
+    }
+    return mRoundedClipOutlineProvider;
   }
 }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/common/SimpleRoundingMethodAdapter.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/common/SimpleRoundingMethodAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.facebook.fresco.samples.showcase.common;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.TextView;
+
+import com.facebook.drawee.generic.RoundingParams;
+
+public class SimpleRoundingMethodAdapter extends BaseAdapter {
+
+  public static SimpleRoundingMethodAdapter createForAllRoundingMethods() {
+    List<Entry> entries = new ArrayList<>();
+    entries.add(new Entry(RoundingParams.RoundingMethod.OVERLAY_COLOR, "overlay_color"));
+    entries.add(new Entry(RoundingParams.RoundingMethod.BITMAP_ONLY, "bitmap_only"));
+    if (Build.VERSION.SDK_INT >= 21) {
+      entries.add(new Entry(RoundingParams.RoundingMethod.OUTLINE, "outline"));
+    }
+    return new SimpleRoundingMethodAdapter(entries);
+  }
+
+  private final List<Entry> mEntries;
+
+  private SimpleRoundingMethodAdapter(List<Entry> entries) {
+    mEntries = entries;
+  }
+
+  @Override
+  public int getCount() {
+    return mEntries.size();
+  }
+
+  @Override
+  public Object getItem(int position) {
+    return mEntries.get(position);
+  }
+
+  @Override
+  public long getItemId(int position) {
+    return position;
+  }
+
+  @Override
+  public View getView(int position, View convertView, ViewGroup parent) {
+    final LayoutInflater layoutInflater = LayoutInflater.from(parent.getContext());
+
+    final View view = convertView != null
+        ? convertView
+        : layoutInflater.inflate(android.R.layout.simple_spinner_dropdown_item, parent, false);
+
+    final TextView textView = (TextView) view.findViewById(android.R.id.text1);
+    textView.setText(mEntries.get(position).description);
+
+    return view;
+  }
+
+  public static class Entry {
+
+    public final RoundingParams.RoundingMethod roundingMethod;
+    public final String description;
+
+    private Entry(
+        RoundingParams.RoundingMethod roundingMethod,
+        String description) {
+      this.roundingMethod = roundingMethod;
+      this.description = description;
+    }
+  }
+}

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeRoundedCornersFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeRoundedCornersFragment.java
@@ -171,13 +171,13 @@ public class DraweeRoundedCornersFragment extends BaseShowcaseFragment {
     hierarchy.setActualImageScaleType(scaleType);
     hierarchy.setActualImageFocusPoint(focusPoint != null ? focusPoint : new PointF(0.5f, 0.5f));
 
-    final RoundingParams roundingParams = Preconditions.checkNotNull(hierarchy.getRoundingParams());
+    final RoundingParams roundingParams = Preconditions.checkNotNull(draweeView.getRoundingParams());
     if (roundingMethod == RoundingParams.RoundingMethod.OVERLAY_COLOR) {
       roundingParams.setOverlayColor(mWindowBackgroundColor);
     } else {
       roundingParams.setRoundingMethod(roundingMethod);
     }
-    hierarchy.setRoundingParams(roundingParams);
+    draweeView.setRoundingParams(roundingParams);
   }
 
   private RoundingParams.RoundingMethod getRoundingMethodForScaleType(ScaleType scaleType) {

--- a/samples/showcase/src/main/res/layout/fragment_drawee_rounded_corners.xml
+++ b/samples/showcase/src/main/res/layout/fragment_drawee_rounded_corners.xml
@@ -75,19 +75,26 @@
   <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/margin_medium"
+      android:layout_marginTop="@dimen/margin_small"
       android:orientation="horizontal"
       >
     <Spinner
         android:id="@+id/scaleType"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
+        android:layout_weight="1"
         android:layout_height="wrap_content"
         />
-    <CheckBox
-        android:id="@+id/borders"
-        android:layout_width="wrap_content"
+    <Spinner
+        android:id="@+id/roundingMethod"
+        android:layout_width="0dp"
+        android:layout_weight="1"
         android:layout_height="wrap_content"
-        android:text="@string/drawee_rounded_corners_borders"
         />
   </LinearLayout>
+  <CheckBox
+      android:id="@+id/borders"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/drawee_rounded_corners_borders"
+      />
 </LinearLayout>

--- a/samples/showcase/src/main/res/values/strings.xml
+++ b/samples/showcase/src/main/res/values/strings.xml
@@ -156,8 +156,7 @@
   <string name="drawee_rounded_corners_some">Only rounding some corners</string>
   <string name="drawee_rounded_corners_fancy">Fancy (different radii)</string>
   <string name="drawee_rounded_corners_borders">Borders</string>
-  <string name="drawee_rounded_corners_bitmap_only_toast">Switched to BITMAP_ONLY rounding method</string>
-  <string name="drawee_rounded_corners_overlay_color_toast">Switched to OVERLAY_COLOR rounding method</string>
+  <string name="drawee_rounded_corners_toast">Switched to %1$s rounding method</string>
 
   <string name="drawee_hierarchy_load_success">Load (success)</string>
   <string name="drawee_hierarchy_load_fail">Load (fail)</string>

--- a/samples/showcase/src/main/res/values/strings.xml
+++ b/samples/showcase/src/main/res/values/strings.xml
@@ -156,7 +156,6 @@
   <string name="drawee_rounded_corners_some">Only rounding some corners</string>
   <string name="drawee_rounded_corners_fancy">Fancy (different radii)</string>
   <string name="drawee_rounded_corners_borders">Borders</string>
-  <string name="drawee_rounded_corners_toast">Switched to %1$s rounding method</string>
 
   <string name="drawee_hierarchy_load_success">Load (success)</string>
   <string name="drawee_hierarchy_load_fail">Load (fail)</string>


### PR DESCRIPTION
## Motivation

Adds a new rounding method using [`View.setOutlineProvider`](https://developer.android.com/reference/android/view/View.html#setOutlineProvider(android.view.ViewOutlineProvider)) to implement rounded corners. Needs API level 21+.

The motivation is to try out whether this improves scroll performance.

Added a new dropdown to the example in the Showcase app to allow people to try out the outline method.

<img width="447" alt="screenshot 2017-04-25 18 25 51" src="https://cloud.githubusercontent.com/assets/346214/25398636/a860b5a4-29e4-11e7-9625-3f09a9a52181.png">

## Limitations

The main limitation is that the new API `View.setOutlineProvider` must be used with Android Views. To use the outline rounding, users must call `draweeView.setRoundingParams(myRoundingParams)`.

The other rounding methods in Fresco work directly with Drawables, and users call `hierarchy.setRoundingParams(myRoundingParams)`.

### Do we want to merge this?

It won't be possible to use this new rounding method with Litho because Litho doesn't use Android Views. Since Litho is used a lot in the Facebook app, this pull request might actually have little benefit for fb. It is a bit of extra code to maintain. Is it worth adding this to Fresco?

## TODO

Borders are not supported yet. Pausing work on borders until we decide whether we want to merge this.

## Test Plan

Ran the Showcase app. Outline rounding works with all scale types:

<img width="480" alt="screenshot 2017-04-25 18 24 07" src="https://cloud.githubusercontent.com/assets/346214/25398657/b70856de-29e4-11e7-9b8d-81e3222716ac.png">

The outline API only supports ellipses and rounded rectangles with uniform corner radius (documented [here](https://developer.android.com/reference/android/graphics/Outline.html#canClip()) and tried [here](http://stackoverflow.com/questions/43548063/android-view-outline-using-a-custom-path)). Therefore non-uniform border radii are not supported:

<img width="449" alt="screenshot 2017-04-25 18 26 53" src="https://cloud.githubusercontent.com/assets/346214/25398729/e856b49c-29e4-11e7-89c3-762ae31a6daa.png">
