### PR TITLE
Support ScaleType in DraweeSpanStringBuilder

### DIFF
--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -147,7 +147,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     final DraweeController controller = draweeHolder.getController();
     if (controller instanceof AbstractDraweeController) {
       ((AbstractDraweeController) controller).addControllerListener(
-          new DrawableChangedListener(draweeSpan, enableResizing, drawableHeightPx, scaleType));
+          new DrawableChangedListener(draweeSpan, enableResizing, drawableWidthPx, drawableHeightPx, scaleType));
     }
     mDraweeSpans.add(draweeSpan);
     setSpan(draweeSpan, startIndex, endIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -306,6 +306,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
 
     private final boolean mEnableResizing;
 
+    private final int mFixedWidth;
     private final int mFixedHeight;
 
     private final int mScaleType;
@@ -315,7 +316,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     }
 
     public DrawableChangedListener(DraweeSpan draweeSpan, boolean enableResizing) {
-      this(draweeSpan, enableResizing, UNSET_SIZE, SCALE_TYPE_RESIZE);
+      this(draweeSpan, enableResizing, UNSET_SIZE, UNSET_SIZE, SCALE_TYPE_RESIZE);
     }
 
     /**
@@ -332,11 +333,13 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     public DrawableChangedListener(
         DraweeSpan draweeSpan,
         boolean enableResizing,
+        int fixedWidth,
         int fixedHeight,
         int scaleType) {
       Preconditions.checkNotNull(draweeSpan);
       mDraweeSpan = draweeSpan;
       mEnableResizing = enableResizing;
+      mFixedWidth = fixedWidth;
       mFixedHeight = fixedHeight;
       mScaleType = scaleType;
     }
@@ -382,7 +385,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         }
       } else if (drawableBounds.width() != imageInfo.getWidth() ||
           drawableBounds.height() != imageInfo.getHeight()) {
-          return new Pair<>(imageInfo.getWidth(), imageInfo.getHeight());
+        return new Pair<>(imageInfo.getWidth(), imageInfo.getHeight());
       }
 
       return null;
@@ -392,10 +395,20 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       int scaledWidth = imageInfo.getWidth();
       int scaledHeight = imageInfo.getHeight();
 
-      if (scaledHeight > mFixedHeight) {
-        final float heightScaleRatio = scaledHeight / (float) mFixedHeight;
-        scaledHeight = mFixedHeight;
-        scaledWidth = (int) (scaledWidth / heightScaleRatio);
+      if (mFixedWidth != UNSET_SIZE) {
+        if (scaledWidth > mFixedWidth) {
+          final float widthScaleRatio = scaledWidth / (float) mFixedWidth;
+          scaledWidth = mFixedWidth;
+          scaledHeight = (int) (scaledHeight / widthScaleRatio);
+        }
+      }
+
+      if (mFixedHeight != UNSET_SIZE) {
+        if (scaledHeight > mFixedHeight) {
+          final float heightScaleRatio = scaledHeight / (float) mFixedHeight;
+          scaledHeight = mFixedHeight;
+          scaledWidth = (int) (scaledWidth / heightScaleRatio);
+        }
       }
 
       return new Pair<>(scaledWidth, scaledHeight);

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -21,6 +21,7 @@ import com.facebook.common.internal.VisibleForTesting;
 import com.facebook.common.lifecycle.AttachDetachListener;
 import com.facebook.drawee.controller.AbstractDraweeController;
 import com.facebook.drawee.controller.BaseControllerListener;
+import com.facebook.drawee.drawable.ScalingUtils;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.interfaces.DraweeHierarchy;
 import com.facebook.drawee.view.DraweeHolder;
@@ -53,17 +54,6 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
   }
 
   public static final int UNSET_SIZE = -1;
-
-  /**
-   * Resizes the drawable according to its requested size, allowing the drawable to grow if needed.
-   */
-  public static final int SCALE_TYPE_RESIZE = 0;
-  /**
-   * Scales the drawable to fit within the bounds specified in
-   * {@link #setImageSpan(DraweeHolder, int, int, int, int, boolean, int, int)}, maintaining
-   * its aspect ratio.
-   */
-  public static final int SCALE_TYPE_CENTER_INSIDE = 1;
 
   private final Set<DraweeSpan> mDraweeSpans = new HashSet<>();
   private final DrawableCallback mDrawableCallback = new DrawableCallback();
@@ -116,7 +106,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         drawableHeightPx,
         enableResizing,
         verticalAlignment,
-        SCALE_TYPE_RESIZE);
+        ScalingUtils.ScaleType.CENTER);
   }
 
   public void setImageSpan(
@@ -127,7 +117,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       final int drawableHeightPx,
       boolean enableResizing,
       @BetterImageSpan.BetterImageSpanAlignment int verticalAlignment,
-      final int scaleType) {
+      final ScalingUtils.ScaleType scaleType) {
     if (endIndex >= length()) {
       // Unfortunately, some callers use this wrong. The original implementation also swallows
       // an exception if this happens (e.g. if you tap on a video that has a minutiae as well.
@@ -307,14 +297,14 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     private final int mFixedWidth;
     private final int mFixedHeight;
 
-    private final int mScaleType;
+    private final ScalingUtils.ScaleType mScaleType;
 
     public DrawableChangedListener(DraweeSpan draweeSpan) {
       this(draweeSpan, false);
     }
 
     public DrawableChangedListener(DraweeSpan draweeSpan, boolean enableResizing) {
-      this(draweeSpan, enableResizing, UNSET_SIZE, UNSET_SIZE, SCALE_TYPE_RESIZE);
+      this(draweeSpan, enableResizing, UNSET_SIZE, UNSET_SIZE, ScalingUtils.ScaleType.CENTER);
     }
 
     /**
@@ -333,7 +323,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         boolean enableResizing,
         int fixedWidth,
         int fixedHeight,
-        int scaleType) {
+        ScalingUtils.ScaleType scaleType) {
       Preconditions.checkNotNull(draweeSpan);
       mDraweeSpan = draweeSpan;
       mEnableResizing = enableResizing;
@@ -353,9 +343,9 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
 
         final Dimens scaledDimens;
 
-        if (mScaleType == SCALE_TYPE_RESIZE) {
+        if (mScaleType == ScalingUtils.ScaleType.CENTER) {
           scaledDimens = getScaledDimensResize(topLevelDrawable, imageInfo);
-        } else if (mScaleType == SCALE_TYPE_CENTER_INSIDE) {
+        } else if (mScaleType == ScalingUtils.ScaleType.CENTER_INSIDE) {
           scaledDimens = getScaledDimensCenterInside(imageInfo);
         } else {
           throw new RuntimeException("invalid scaleType: " + mScaleType);

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -135,7 +135,12 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     final DraweeController controller = draweeHolder.getController();
     if (controller instanceof AbstractDraweeController) {
       ((AbstractDraweeController) controller).addControllerListener(
-          new DrawableChangedListener(draweeSpan, enableResizing, drawableWidthPx, drawableHeightPx, scaleType));
+          new DrawableChangedListener(
+              draweeSpan,
+              enableResizing,
+              drawableWidthPx,
+              drawableHeightPx,
+              scaleType));
     }
     mDraweeSpans.add(draweeSpan);
     setSpan(draweeSpan, startIndex, endIndex + 1, SPAN_EXCLUSIVE_EXCLUSIVE);

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -56,7 +56,15 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
 
   public static final int UNSET_SIZE = -1;
 
+  /**
+   * Resizes the drawable according to its requested size, allowing the drawable to grow if needed.
+   */
   public static final int SCALE_TYPE_RESIZE = 0;
+  /**
+   * Scales the drawable to fit within the bounds specified in
+   * {@link #setImageSpan(DraweeHolder, int, int, int, int, boolean, int, int)}, maintaining
+   * its aspect ratio.
+   */
   public static final int SCALE_TYPE_CENTER_INSIDE = 1;
 
   private final Set<DraweeSpan> mDraweeSpans = new HashSet<>();

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -13,8 +13,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
-import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 import android.text.SpannableStringBuilder;
 import android.view.View;
 
@@ -353,7 +351,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       if (mFixedHeight != UNSET_SIZE && imageInfo != null) {
         Drawable topLevelDrawable = mDraweeSpan.getDraweeHolder().getTopLevelDrawable();
 
-        final Pair<Integer, Integer> scaledDimens;
+        final Dimens scaledDimens;
 
         if (mScaleType == SCALE_TYPE_RESIZE) {
           scaledDimens = getScaledDimensResize(topLevelDrawable, imageInfo);
@@ -364,7 +362,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         }
 
         if (scaledDimens != null) {
-          topLevelDrawable.setBounds(0, 0, scaledDimens.first, scaledDimens.second);
+          topLevelDrawable.setBounds(0, 0, scaledDimens.width, scaledDimens.height);
 
           if (mDraweeSpanChangedListener != null) {
             mDraweeSpanChangedListener.onDraweeSpanChanged(DraweeSpanStringBuilder.this);
@@ -373,7 +371,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       }
     }
 
-    private @Nullable Pair<Integer, Integer> getScaledDimensResize(final Drawable drawable, final ImageInfo imageInfo) {
+    private Dimens getScaledDimensResize(final Drawable drawable, final ImageInfo imageInfo) {
       final Rect drawableBounds = drawable.getBounds();
       if (mEnableResizing && mDraweeSpan.getDraweeHolder().getTopLevelDrawable() != null) {
         float imageWidth = ((float) mFixedHeight / imageInfo.getHeight()) * imageInfo.getWidth();
@@ -381,17 +379,17 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         if (drawableBounds.width() != imageWidthPx ||
             drawableBounds.height() != mFixedHeight) {
 
-          return new Pair<>(imageWidthPx, mFixedHeight);
+          return new Dimens(imageWidthPx, mFixedHeight);
         }
       } else if (drawableBounds.width() != imageInfo.getWidth() ||
           drawableBounds.height() != imageInfo.getHeight()) {
-        return new Pair<>(imageInfo.getWidth(), imageInfo.getHeight());
+        return new Dimens(imageInfo.getWidth(), imageInfo.getHeight());
       }
 
       return null;
     }
 
-    private Pair<Integer, Integer> getScaledDimensCenterInside(final ImageInfo imageInfo) {
+    private Dimens getScaledDimensCenterInside(final ImageInfo imageInfo) {
       int scaledWidth = imageInfo.getWidth();
       int scaledHeight = imageInfo.getHeight();
 
@@ -411,7 +409,18 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         }
       }
 
-      return new Pair<>(scaledWidth, scaledHeight);
+      return new Dimens(scaledWidth, scaledHeight);
+    }
+  }
+
+  public static class Dimens {
+
+    private final int width;
+    private final int height;
+
+    public Dimens(int width, int height) {
+      this.width = width;
+      this.height = height;
     }
   }
 }

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -345,8 +345,8 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
 
         if (mScaleType == ScalingUtils.ScaleType.CENTER) {
           scaledDimens = getScaledDimensCenter(topLevelDrawable, imageInfo);
-        } else if (mScaleType == ScalingUtils.ScaleType.CENTER_INSIDE) {
-          scaledDimens = getScaledDimensCenterInside(imageInfo);
+        } else if (mScaleType == ScalingUtils.ScaleType.FIT_START) {
+          scaledDimens = getScaledDimensFitStart(imageInfo);
         } else {
           throw new RuntimeException("invalid scaleType: " + mScaleType);
         }
@@ -379,7 +379,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       return null;
     }
 
-    private Dimens getScaledDimensCenterInside(final ImageInfo imageInfo) {
+    private Dimens getScaledDimensFitStart(final ImageInfo imageInfo) {
       int scaledWidth = imageInfo.getWidth();
       int scaledHeight = imageInfo.getHeight();
 

--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -338,13 +338,13 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
         ImageInfo imageInfo,
         Animatable animatable) {
 
-      if (mFixedHeight != UNSET_SIZE && imageInfo != null) {
+      if (mEnableResizing && mFixedHeight != UNSET_SIZE && imageInfo != null) {
         Drawable topLevelDrawable = mDraweeSpan.getDraweeHolder().getTopLevelDrawable();
 
         final Dimens scaledDimens;
 
         if (mScaleType == ScalingUtils.ScaleType.CENTER) {
-          scaledDimens = getScaledDimensResize(topLevelDrawable, imageInfo);
+          scaledDimens = getScaledDimensCenter(topLevelDrawable, imageInfo);
         } else if (mScaleType == ScalingUtils.ScaleType.CENTER_INSIDE) {
           scaledDimens = getScaledDimensCenterInside(imageInfo);
         } else {
@@ -361,9 +361,9 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
       }
     }
 
-    private Dimens getScaledDimensResize(final Drawable drawable, final ImageInfo imageInfo) {
+    private Dimens getScaledDimensCenter(final Drawable drawable, final ImageInfo imageInfo) {
       final Rect drawableBounds = drawable.getBounds();
-      if (mEnableResizing && mDraweeSpan.getDraweeHolder().getTopLevelDrawable() != null) {
+      if (mDraweeSpan.getDraweeHolder().getTopLevelDrawable() != null) {
         float imageWidth = ((float) mFixedHeight / imageInfo.getHeight()) * imageInfo.getWidth();
         int imageWidthPx = (int) imageWidth;
         if (drawableBounds.width() != imageWidthPx ||


### PR DESCRIPTION
Adds support for `ScaleType.FIT_START` to `DraweeSpanStringBuilder`. Maintains original API and specifies previous (now default) behavior as `ScaleType.CENTER`.

## Motivation

A common use case (especially in chat apps when dealing with emojis) is to display images in their native aspect ratio without letting them grow indefinitely.

Below is a screenshot where the first line of text uses `ScaleType.CENTER` and the second line of text uses `ScaleType.FIT_START`.

![fresco_screenshot](https://cloud.githubusercontent.com/assets/8857134/25412564/6ba7ec88-29d8-11e7-80fa-4a93cefb3960.png)

Other scale types should be easy to add as needed, but I currently only need `ScaleType.FIT_START` so I would like to get feedback on this implementation before supporting other scale types.

## Test Plan

Wrote sample app that tests new behavior (see screenshot), tests still run as expected.

## Next Steps

- [ ] Some concessions were made in order to keep the current (1.3.0) API intact. I believe that `enableResizing` should be dropped everywhere as it introduces ambiguity, and instead I should directly reference `ScaleType.FIT_XY`. However this breaks the current API and I want Fresco maintainers' feedback on that before making a breaking change.
- [ ] I have implemented the computation of new bounds myself, though recently I realized I should instead be trying to funnel that computation through `ScalingUtils` instead. This should be addressed before merging -- as-is, those computations do not have tests so I would like to instead piggyback off of the battle-tested `ScalingUtils`.

Thank you for considering this PR and all feedback is of course appreciated :)