### PR TITLE
fix partial bitmap got displayed

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
@@ -418,8 +418,12 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
     @Override
     protected synchronized boolean updateDecodeJob(EncodedImage encodedImage, boolean isLast) {
       boolean ret = super.updateDecodeJob(encodedImage, isLast);
-      if (!isLast && EncodedImage.isValid(encodedImage) &&
-          encodedImage.getImageFormat() == DefaultImageFormats.JPEG) {
+      if (!isLast && EncodedImage.isValid(encodedImage)) {
+        if (encodedImage.getImageFormat() != DefaultImageFormats.JPEG) {
+          // decoding a partial image data of none jpeg type and displaying that result bitmap
+          // to the user have no sense.
+          return ret && isNotPartialData(encodedImage);
+        }
         if (!mProgressiveJpegParser.parseMoreData(encodedImage)) {
           return false;
         }
@@ -437,6 +441,10 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
         mLastScheduledScanNumber = scanNum;
       }
       return ret;
+    }
+
+    private boolean isNotPartialData(EncodedImage encodedImage) {
+      return encodedImage.getEncodedCacheKey() != null;
     }
 
     @Override


### PR DESCRIPTION
## Motivation 
when loading an image for the first time with media-variations enabled, decode producer could got a set of partial images but of none progressive jpeg image format (i.e. webp) continuously from network fetch producer if **under poor network condition**, these partial bitmaps would be treated like progressive jpegs , however a none fully decoded webp image is not useful to the user as the bitmap used to render this partial image may contains lots of pixels not set (observed as pure black or white)
![partial_webp](https://cloud.githubusercontent.com/assets/8196770/25736944/9ea59b90-31a7-11e7-86a6-6f1aa5e5a9b5.gif)

## Test Plan
use web debugging tools like Charles to simulate a pool network conditions, and loading a none jpeg image, make sure no partial bitmap got displayed