### PR TITLE
Fix CircleCI: Explicit NDK unzip target location

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
     - if [ ! -d "/usr/local/android-sdk-linux/build-tools/26.0.0" ]; then echo y | android update sdk --no-ui --all --filter "build-tools-26.0.0"; fi
     - if [ ! -d "/usr/local/android_sdk/extras/android/m2repository/com/android/support/support-core-utils/25.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
     # setup NDK r15b
-    - if [ ! -d "/home/ubuntu/android-ndk-r15b" ]; then wget https://dl.google.com/android/repository/android-ndk-r15b-linux-x86_64.zip; unzip android-ndk-r15b-linux-x86_64.zip; fi
+    - if [ ! -d "/home/ubuntu/android-ndk-r15b" ]; then wget https://dl.google.com/android/repository/android-ndk-r15b-linux-x86_64.zip; unzip android-ndk-r15b-linux-x86_64.zip -d "/home/ubuntu"; fi
     - echo "ndk.dir=/home/ubuntu/android-ndk-r15b" >> "/home/ubuntu/fresco/local.properties"
 
 test:


### PR DESCRIPTION
## Motivation

CircleCI was broken by the last changes to update the NDK. As a result Circle-CI failed on all current builds.

The underlying reason is that the pre-configuration commands are executed in the `/home/ubuntu/fresco` folder, but were supposed to run in `/home/ubuntu`. Subsequently, the NDK ended up in a wrong location.

## Fix

Adding the explicit destination folder to the `unzip` command using the `-d destination_folder` option.

## Test Plan

Circle CI passes after this change: https://circleci.com/gh/facebook/fresco/1012 (or see below).