### PR TITLE
Fix promo button links

### DIFF
--- a/docs/_data/promo.yml
+++ b/docs/_data/promo.yml
@@ -1,10 +1,7 @@
 - type: plugin_row
   children:
   - type: button
-    href: docs/getting-started.html
-    text: Get Started
-  - type: button
     href: docs/index.html
-    text: Download
+    text: Get Started
 
 - type: github_star


### PR DESCRIPTION
## Motivation (required)

The "Getting Started" button link is broken

This broke with the new documentation from 07271efe18222fa1744bb7604c2e1aeb6ee94930

## Test Plan (required)

Did run changes locally and button now correctly links to the "Getting Started with Fresco" page