### PR TITLE
[docs] fix redirect loop

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'github-pages', '~> 104', group: :jekyll_plugins
+gem 'github-pages', '~> 145', group: :jekyll_plugins

--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <meta http-equiv="refresh" content="0; {{ page.destination }}">
+  <meta http-equiv="refresh" content="0; {{ page.redirect.to }}">
 </head>
 <body></body>
 </html>


### PR DESCRIPTION
## Motivation

Redirects are broken (e.g. http://frescolib.org/docs/using-drawees-xml.html), we should fix this.

## Test Plan

Update `github-pages` gem to latest version, this triggers the repro locally. Update redirect template to use correct variables -> repro goes away.