### PR TITLE
Support for local content video uri thumbnail loading

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -363,7 +363,7 @@ public class ImagePipelineFactory {
     if (mProducerSequenceFactory == null) {
       mProducerSequenceFactory =
           new ProducerSequenceFactory(
-              mConfig.getContext(),
+              mConfig.getContext().getApplicationContext().getContentResolver(),
               getProducerFactory(),
               mConfig.getNetworkFetcher(),
               mConfig.isResizeAndRotateEnabledForNetwork(),

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -363,6 +363,7 @@ public class ImagePipelineFactory {
     if (mProducerSequenceFactory == null) {
       mProducerSequenceFactory =
           new ProducerSequenceFactory(
+              mConfig.getContext(),
               getProducerFactory(),
               mConfig.getNetworkFetcher(),
               mConfig.isResizeAndRotateEnabledForNetwork(),

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerFactory.java
@@ -9,8 +9,6 @@
 
 package com.facebook.imagepipeline.core;
 
-import javax.annotation.Nullable;
-
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.AssetManager;
@@ -67,6 +65,8 @@ import com.facebook.imagepipeline.producers.ThrottlingProducer;
 import com.facebook.imagepipeline.producers.ThumbnailBranchProducer;
 import com.facebook.imagepipeline.producers.ThumbnailProducer;
 import com.facebook.imagepipeline.producers.WebpTranscodeProducer;
+
+import javax.annotation.Nullable;
 
 public class ProducerFactory {
 
@@ -296,7 +296,8 @@ public class ProducerFactory {
   }
 
   public LocalVideoThumbnailProducer newLocalVideoThumbnailProducer() {
-    return new LocalVideoThumbnailProducer(mExecutorSupplier.forLocalStorageRead());
+    return new LocalVideoThumbnailProducer(mExecutorSupplier.forLocalStorageRead(),
+      mContentResolver);
   }
 
   public NetworkFetchProducer newNetworkFetchProducer(NetworkFetcher networkFetcher) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerSequenceFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerSequenceFactory.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import android.content.ContentResolver;
-import android.content.Context;
 import android.net.Uri;
 
 import com.facebook.common.internal.Preconditions;
@@ -98,7 +97,7 @@ public class ProducerSequenceFactory {
       mBitmapPrepareSequences;
 
   public ProducerSequenceFactory(
-      Context context,
+      ContentResolver contentResolver,
       ProducerFactory producerFactory,
       NetworkFetcher networkFetcher,
       boolean resizeAndRotateEnabledForNetwork,
@@ -107,7 +106,7 @@ public class ProducerSequenceFactory {
       boolean useDownsamplingRatio,
       boolean useBitmapPrepareToDraw,
       boolean partialImageCachingEnabled) {
-    mContentResolver = context.getApplicationContext().getContentResolver();
+    mContentResolver = contentResolver;
     mProducerFactory = producerFactory;
     mNetworkFetcher = networkFetcher;
     mResizeAndRotateEnabledForNetwork = resizeAndRotateEnabledForNetwork;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerSequenceFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerSequenceFactory.java
@@ -12,10 +12,13 @@ package com.facebook.imagepipeline.core;
 import java.util.HashMap;
 import java.util.Map;
 
+import android.content.ContentResolver;
+import android.content.Context;
 import android.net.Uri;
 
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.internal.VisibleForTesting;
+import com.facebook.common.media.MediaUtils;
 import com.facebook.common.memory.PooledByteBuffer;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.common.webp.WebpSupportStatus;
@@ -55,6 +58,7 @@ import static com.facebook.imagepipeline.common.SourceUriType.SOURCE_TYPE_QUALIF
 
 public class ProducerSequenceFactory {
 
+  private final ContentResolver mContentResolver;
   private final ProducerFactory mProducerFactory;
   private final NetworkFetcher mNetworkFetcher;
   private final boolean mResizeAndRotateEnabledForNetwork;
@@ -94,6 +98,7 @@ public class ProducerSequenceFactory {
       mBitmapPrepareSequences;
 
   public ProducerSequenceFactory(
+      Context context,
       ProducerFactory producerFactory,
       NetworkFetcher networkFetcher,
       boolean resizeAndRotateEnabledForNetwork,
@@ -102,6 +107,7 @@ public class ProducerSequenceFactory {
       boolean useDownsamplingRatio,
       boolean useBitmapPrepareToDraw,
       boolean partialImageCachingEnabled) {
+    mContentResolver = context.getApplicationContext().getContentResolver();
     mProducerFactory = producerFactory;
     mNetworkFetcher = networkFetcher;
     mResizeAndRotateEnabledForNetwork = resizeAndRotateEnabledForNetwork;
@@ -249,6 +255,9 @@ public class ProducerSequenceFactory {
       case SOURCE_TYPE_LOCAL_IMAGE_FILE:
         return getLocalImageFileFetchSequence();
       case SOURCE_TYPE_LOCAL_CONTENT:
+        if (MediaUtils.isVideo(mContentResolver.getType(uri))) {
+          return getLocalVideoFileFetchSequence();
+        }
         return getLocalContentUriFetchSequence();
       case SOURCE_TYPE_LOCAL_ASSET:
         return getLocalAssetFetchSequence();

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -9,12 +9,16 @@
 
 package com.facebook.imagepipeline.producers;
 
+import java.util.Map;
+import java.util.concurrent.Executor;
+
 import android.content.ContentResolver;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.provider.MediaStore;
+import android.support.annotation.Nullable;
 
 import com.facebook.common.internal.ImmutableMap;
 import com.facebook.common.internal.VisibleForTesting;
@@ -25,9 +29,6 @@ import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.CloseableStaticBitmap;
 import com.facebook.imagepipeline.image.ImmutableQualityInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
-
-import java.util.Map;
-import java.util.concurrent.Executor;
 
 /**
  * A producer that creates video thumbnails.
@@ -77,8 +78,12 @@ public class LocalVideoThumbnailProducer implements
 
           @Override
           protected CloseableReference<CloseableImage> getResult() throws Exception {
-            Bitmap thumbnailBitmap = ThumbnailUtils.createVideoThumbnail(
-              getLocalFilePath(imageRequest), calculateKind(imageRequest));
+            String path = getLocalFilePath(imageRequest);
+            if (path == null) {
+              return null;
+            }
+            Bitmap thumbnailBitmap = ThumbnailUtils.createVideoThumbnail(path,
+                calculateKind(imageRequest));
             if (thumbnailBitmap == null) {
               return null;
             }
@@ -119,7 +124,7 @@ public class LocalVideoThumbnailProducer implements
     return MediaStore.Images.Thumbnails.MICRO_KIND;
   }
 
-  private String getLocalFilePath(ImageRequest imageRequest) {
+  @Nullable private String getLocalFilePath(ImageRequest imageRequest) {
     Uri uri = imageRequest.getSourceUri();
     if (UriUtil.isLocalFileUri(uri)) {
       return imageRequest.getSourceFile().getPath();
@@ -134,6 +139,6 @@ public class LocalVideoThumbnailProducer implements
         cursor.close();
       }
     }
-    return "";
+    return null;
   }
 }

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ProducerSequenceFactoryTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ProducerSequenceFactoryTest.java
@@ -31,6 +31,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static com.facebook.imagepipeline.common.SourceUriType.SOURCE_TYPE_LOCAL_ASSET;
@@ -71,8 +72,9 @@ public class ProducerSequenceFactoryTest {
 
     ProducerFactory producerFactory = mock(ProducerFactory.class, RETURNS_MOCKS);
 
-    mProducerSequenceFactory =
-        new ProducerSequenceFactory(producerFactory, null, true, false, null, false, false, false);
+    mProducerSequenceFactory = new ProducerSequenceFactory(
+        RuntimeEnvironment.application,
+        producerFactory, null, true, false, null, false, false, false);
 
     when(mImageRequest.getLowestPermittedRequestLevel())
         .thenReturn(ImageRequest.RequestLevel.FULL_FETCH);
@@ -318,6 +320,7 @@ public class ProducerSequenceFactoryTest {
   private void internalUseSequenceFactoryWithBitmapPrepare() {
     ProducerFactory producerFactory = mock(ProducerFactory.class, RETURNS_MOCKS);
     mProducerSequenceFactory = new ProducerSequenceFactory(
+        RuntimeEnvironment.application,
         producerFactory,
         null,
         true,

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ProducerSequenceFactoryTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ProducerSequenceFactoryTest.java
@@ -73,7 +73,7 @@ public class ProducerSequenceFactoryTest {
     ProducerFactory producerFactory = mock(ProducerFactory.class, RETURNS_MOCKS);
 
     mProducerSequenceFactory = new ProducerSequenceFactory(
-        RuntimeEnvironment.application,
+        RuntimeEnvironment.application.getContentResolver(),
         producerFactory, null, true, false, null, false, false, false);
 
     when(mImageRequest.getLowestPermittedRequestLevel())
@@ -320,7 +320,7 @@ public class ProducerSequenceFactoryTest {
   private void internalUseSequenceFactoryWithBitmapPrepare() {
     ProducerFactory producerFactory = mock(ProducerFactory.class, RETURNS_MOCKS);
     mProducerSequenceFactory = new ProducerSequenceFactory(
-        RuntimeEnvironment.application,
+        RuntimeEnvironment.application.getContentResolver(),
         producerFactory,
         null,
         true,

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducerTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducerTest.java
@@ -77,7 +77,8 @@ public class LocalVideoThumbnailProducerTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     mExecutor = new TestExecutorService(new FakeClock());
-    mLocalVideoThumbnailProducer = new LocalVideoThumbnailProducer(mExecutor);
+    mLocalVideoThumbnailProducer = new LocalVideoThumbnailProducer(mExecutor,
+        RuntimeEnvironment.application.getContentResolver());
     mFile = new File(RuntimeEnvironment.application.getExternalFilesDir(null), TEST_FILENAME);
 
     mockStatic(ThumbnailUtils.class);


### PR DESCRIPTION
Current local content URI only supports image loading, the thumbnail for video is only supported by file path uri.
