### PR TITLE
(ImageFormatChecker.java) run default format checkers before custom ones

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imageformat/ImageFormatChecker.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imageformat/ImageFormatChecker.java
@@ -50,19 +50,20 @@ public class ImageFormatChecker {
     final byte[] imageHeaderBytes = new byte[mMaxHeaderLength];
     final int headerSize = readHeaderFromStream(mMaxHeaderLength, is, imageHeaderBytes);
 
+    ImageFormat format = mDefaultFormatChecker.determineFormat(imageHeaderBytes, headerSize);
+    if (format != null && format != ImageFormat.UNKNOWN) {
+      return format;
+    }
+
     if (mCustomImageFormatCheckers != null) {
       for (ImageFormat.FormatChecker formatChecker : mCustomImageFormatCheckers) {
-        ImageFormat format = formatChecker.determineFormat(imageHeaderBytes, headerSize);
+        format = formatChecker.determineFormat(imageHeaderBytes, headerSize);
         if (format != null && format != ImageFormat.UNKNOWN) {
           return format;
         }
       }
     }
-    ImageFormat format = mDefaultFormatChecker.determineFormat(imageHeaderBytes, headerSize);
-    if (format == null) {
-      format = ImageFormat.UNKNOWN;
-    }
-    return format;
+    return ImageFormat.UNKNOWN;
   }
 
   private void updateMaxHeaderLength() {


### PR DESCRIPTION
## Motivation (required)

Searching for default formats aught to go first.

## Test Plan (required)

-Run test suite.
-Ensure that all file types in Showcase app still work.
