### PR TITLE
AbstractDraweeControllerBuilder#setDataSourceSupplier now returns BUILDER

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeControllerBuilder.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeControllerBuilder.java
@@ -179,8 +179,9 @@ public abstract class AbstractDraweeControllerBuilder <
    *
    *  <p/> Note: This is mutually exclusive with other image request setters.
    */
-  public void setDataSourceSupplier(@Nullable Supplier<DataSource<IMAGE>> dataSourceSupplier) {
+  public BUILDER setDataSourceSupplier(@Nullable Supplier<DataSource<IMAGE>> dataSourceSupplier) {
     mDataSourceSupplier = dataSourceSupplier;
+    return getThis();
   }
 
   /**


### PR DESCRIPTION
AbstractDraweeControllerBuilder#setDataSourceSupplier now returns BUILDER

Allow supplier to be set when building the controller.
```
Fresco.newDraweeControllerBuilder()
            .setDataSourceSupplier(supplier)
            .build()
```

Closes #1958