### PR TITLE
Issue 1940: Fix animated images not playing in SimpleDraweeSpanTextView

### DIFF
--- a/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
+++ b/drawee-span/src/main/java/com/facebook/drawee/span/DraweeSpanStringBuilder.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
+import android.os.SystemClock;
 import android.text.SpannableStringBuilder;
 import android.view.View;
 import com.facebook.common.internal.Preconditions;
@@ -250,7 +251,11 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     @Override
     public void scheduleDrawable(Drawable who, Runnable what, long when) {
       if (mBoundView != null) {
-        mBoundView.scheduleDrawable(who, what, when);
+        // 'mBoundView.scheduleDrawable(who, what, when)' wouldn't work because
+        // it cannot determine the 'who' drawable with 'verifyDrawable(who)' method.
+        // So we're re-implement 'scheduleDrawable' manually.
+        final long delay = when - SystemClock.uptimeMillis();
+        mBoundView.postDelayed(what, delay);
       } else if (mBoundDrawable != null) {
         mBoundDrawable.scheduleSelf(what, when);
       }
@@ -259,7 +264,7 @@ public class DraweeSpanStringBuilder extends SpannableStringBuilder
     @Override
     public void unscheduleDrawable(Drawable who, Runnable what) {
       if (mBoundView != null) {
-        unscheduleDrawable(who, what);
+        mBoundView.removeCallbacks(what);
       } else if (mBoundDrawable != null) {
         mBoundDrawable.unscheduleSelf(what);
       }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeSpanSimpleTextFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/DraweeSpanSimpleTextFragment.java
@@ -42,6 +42,7 @@ public class DraweeSpanSimpleTextFragment extends BaseShowcaseFragment {
   private SimpleDraweeSpanTextView mDraweeSpanTextView;
   private ScalingUtils.ScaleType mScaleType;
   private Uri mInlineImageUri;
+  private Uri mInlineAnimatedImageUri;
 
   @Nullable
   @Override
@@ -54,6 +55,9 @@ public class DraweeSpanSimpleTextFragment extends BaseShowcaseFragment {
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     final ImageUriProvider imageUriProvider = ImageUriProvider.getInstance(getContext());
     mInlineImageUri = imageUriProvider.createSampleUri(ImageUriProvider.ImageSize.M);
+    mInlineAnimatedImageUri = Uri.parse(
+        "http://frescolib.org/static/sample-images/fresco_logo_anim_full_frames_with_pause_m.gif"
+    );
 
     mDraweeSpanTextView = (SimpleDraweeSpanTextView) view.findViewById(R.id.drawee_text_view);
     final Spinner scaleType = (Spinner) view.findViewById(R.id.scaleType);
@@ -97,6 +101,27 @@ public class DraweeSpanSimpleTextFragment extends BaseShowcaseFragment {
         draweeHierarchy, /* hierarchy to be used */
         controller, /* controller to be used to update the hierarchy */
         imagePosition, /* image index within the text */
+        200, /* image width */
+        200, /* image height */
+        false, /* auto resize */
+        DraweeSpan.ALIGN_CENTER); /* alignment */
+
+    int imagePosition2 = text.indexOf('%');
+
+    DraweeHierarchy draweeAnimatedHierarchy = GenericDraweeHierarchyBuilder.newInstance(getResources())
+        .setPlaceholderImage(new ColorDrawable(Color.RED))
+        .setActualImageScaleType(mScaleType)
+        .build();
+    DraweeController animatedController = Fresco.newDraweeControllerBuilder()
+        .setUri(mInlineAnimatedImageUri)
+        .setAutoPlayAnimations(true)
+        .build();
+
+    draweeSpanStringBuilder.setImageSpan(
+        getContext(), /* Context */
+        draweeAnimatedHierarchy, /* hierarchy to be used */
+        animatedController, /* controller to be used to update the hierarchy */
+        imagePosition2, /* image index within the text */
         200, /* image width */
         200, /* image height */
         false, /* auto resize */

--- a/samples/showcase/src/main/res/values/strings.xml
+++ b/samples/showcase/src/main/res/values/strings.xml
@@ -27,7 +27,7 @@
   <string name="drawee_scale_type_help">Select either the landscape or portrait picture. Then select a scale type to apply for the large Drawee.</string>
 
   <string name="drawee_span_simple_title">Simple DraweeSpan</string>
-  <string name="drawee_span_simple_text">Text with an # inline image using a DraweeSpan.</string>
+  <string name="drawee_span_simple_text">Text with an # inline image using a DraweeSpan. Also works with an % animated images!</string>
   <string name="drawee_span_simple_help">This example shows how to render text with an inline image. Change the scale type using the drop-down menu.</string>
 
   <string name="drawee_rounded_corners_title">Rounded Corners</string>


### PR DESCRIPTION
## Motivation (required)

The pull request solves [issue#1940](https://github.com/facebook/fresco/issues/1940). Also it's fix that unscheduleDrawable() calls itself recursively (if it was ever called).

## Test Plan (required)

- Run tests.
- Ensure that DraweeSpan in Showcase app works properly (fist span is still, second is animating).