### PR TITLE
Issue #1969 Fix LocalVideoThumbnailProducer#getLocalFilePath for videos from Android document provider.

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -14,6 +14,8 @@ import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
+import android.os.Build;
+import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import android.support.annotation.Nullable;
 import com.facebook.common.internal.ImmutableMap;
@@ -128,13 +130,22 @@ public class LocalVideoThumbnailProducer implements
     if (UriUtil.isLocalFileUri(uri)) {
       return imageRequest.getSourceFile().getPath();
     } else if (UriUtil.isLocalContentUri(uri)) {
+      String selection = null;
+      String[] selectionArgs = null;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+          && "com.android.providers.media.documents".equals(uri.getAuthority())) {
+        String documentId = DocumentsContract.getDocumentId(uri);
+        uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+        selection = MediaStore.Video.Media._ID + "=?";
+        selectionArgs = new String[]{documentId.split(":")[1]};
+      }
       Cursor cursor = mContentResolver.query(
           uri,
           new String[]{
               MediaStore.Video.Media.DATA
           },
-          null,
-          null,
+          selection,
+          selectionArgs,
           null);
       try {
         if (cursor != null && cursor.moveToFirst()) {


### PR DESCRIPTION
## Motivation (required)

This resolves #1969.
`LocalVideoThumbnailProducer#getLocalFilePath` will return null for uris like `content://com.android.providers.media.documents/document/video%3A160`. Inspired by https://github.com/iPaulPro/aFileChooser/blob/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java, this PR just fix this case.

## Test Plan (required)

Since this method is private and the test uri in `LocalVideoThumbnailProducerTest` is just a mocked uri starts with `file://`, there is no test to cover.

