### PR TITLE
Fix all build.gradle files to use new deps declarations

### DIFF
--- a/animated-base-test/build.gradle
+++ b/animated-base-test/build.gradle
@@ -6,19 +6,19 @@ version = VERSION_NAME
 
 
 dependencies {
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    compile project(':fbcore')
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':fbcore')
 
-    compile "junit:junit:${JUNIT_VERSION}"
-    compile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    compile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    implementation "junit:junit:${JUNIT_VERSION}"
+    implementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    implementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    compile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    compile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    compile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    implementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    implementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    implementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/animated-base/build.gradle
+++ b/animated-base/build.gradle
@@ -6,27 +6,27 @@ version = VERSION_NAME
 
 
 dependencies {
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    provided "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    compile project(':fbcore')
-    compile project(':imagepipeline-base')
-    compile project(':imagepipeline')
-    compile project(':animated-drawable')
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    compileOnly "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    api project(':fbcore')
+    api project(':imagepipeline-base')
+    api project(':imagepipeline')
+    api project(':animated-drawable')
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
 
-    testCompile project(':animated-base-test')
-    testCompile project(':imagepipeline-test')
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    testCompile "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testCompile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    testImplementation project(':animated-base-test')
+    testImplementation project(':imagepipeline-test')
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    testCompile "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    testImplementation "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/animated-drawable/build.gradle
+++ b/animated-drawable/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
+    testImplementation "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
     testImplementation "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     testImplementation "junit:junit:${JUNIT_VERSION}"
     testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"

--- a/animated-webp/build.gradle
+++ b/animated-webp/build.gradle
@@ -5,23 +5,23 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    compile project(':static-webp')
-    compile project(':animated-base')
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':static-webp')
+    implementation project(':animated-base')
 
-    testCompile project(':imagepipeline-base-test')
-    testCompile project(':imagepipeline-test')
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testCompile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    testImplementation project(':imagepipeline-base-test')
+    testImplementation project(':imagepipeline-test')
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    testCompile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/drawee-backends/drawee-volley/build.gradle
+++ b/drawee-backends/drawee-volley/build.gradle
@@ -4,12 +4,12 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.android.volley:volley:${VOLLEY_VERSION}"
+    compileOnly "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    implementation "com.android.volley:volley:${VOLLEY_VERSION}"
 
-    compile project(':drawee')
-    compile project(':fbcore')
+    implementation project(':drawee')
+    implementation project(':fbcore')
 }
 apply from: rootProject.file('release.gradle')
 

--- a/drawee-span/build.gradle
+++ b/drawee-span/build.gradle
@@ -5,16 +5,16 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
 
-    compile project(path: ':drawee')
-    compile project(path: ':fbcore')
-    compile project(path: ':imagepipeline-base')
+    implementation project(path: ':drawee')
+    implementation project(path: ':fbcore')
+    implementation project(path: ':imagepipeline-base')
 
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    testCompile "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/imagepipeline-backends/imagepipeline-okhttp/build.gradle
+++ b/imagepipeline-backends/imagepipeline-okhttp/build.gradle
@@ -4,10 +4,10 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-  compile "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"
+  implementation "com.squareup.okhttp:okhttp:${OKHTTP_VERSION}"
 
-  compile project(':fbcore')
-  compile project(':imagepipeline')
+  implementation project(':fbcore')
+  implementation project(':imagepipeline')
 }
 apply from: rootProject.file('release.gradle')
 

--- a/imagepipeline-backends/imagepipeline-okhttp3/build.gradle
+++ b/imagepipeline-backends/imagepipeline-okhttp3/build.gradle
@@ -4,10 +4,10 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-  compile "com.squareup.okhttp3:okhttp:${OKHTTP3_VERSION}"
+  implementation "com.squareup.okhttp3:okhttp:${OKHTTP3_VERSION}"
 
-  compile project(':fbcore')
-  compile project(':imagepipeline')
+  implementation project(':fbcore')
+  implementation project(':imagepipeline')
 }
 apply from: rootProject.file('release.gradle')
 

--- a/imagepipeline-backends/imagepipeline-volley/build.gradle
+++ b/imagepipeline-backends/imagepipeline-volley/build.gradle
@@ -4,11 +4,11 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-  compile "com.android.volley:volley:${VOLLEY_VERSION}"
+  implementation "com.android.volley:volley:${VOLLEY_VERSION}"
 
-  compile project(':fbcore')
-  compile project(':imagepipeline')
-  compile project(':imagepipeline-base')
+  implementation project(':fbcore')
+  implementation project(':imagepipeline')
+  implementation project(':imagepipeline-base')
 }
 apply from: rootProject.file('release.gradle')
 

--- a/imagepipeline-base-test/build.gradle
+++ b/imagepipeline-base-test/build.gradle
@@ -5,11 +5,12 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    compile "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    compile project(':fbcore')
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+
+    implementation "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':fbcore')
 }
 apply from: rootProject.file('release.gradle')
 
@@ -36,7 +37,7 @@ task jarTest (type: Jar) {
 }
 
 configurations {
-    testOutput.extendsFrom (testCompile)
+    testOutput.extendsFrom (testImplementation)
 }
 
 artifacts.add('archives', sourcesJar)

--- a/imagepipeline-base/build.gradle
+++ b/imagepipeline-base/build.gradle
@@ -5,28 +5,29 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
-    provided "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
-    provided "com.facebook.infer.annotation:infer-annotation:${INFER_ANNOTATION_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    compile project(':fbcore')
+    compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.facebook.infer.annotation:infer-annotation:${INFER_ANNOTATION_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    testCompile "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testCompile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':fbcore')
+
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    testCompile "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    testImplementation "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }
-    testCompile project(path: ':imagepipeline-base-test')
+    testImplementation project(path: ':imagepipeline-base-test')
 }
 apply from: rootProject.file('release.gradle')
 
@@ -56,7 +57,7 @@ task jarTest (type: Jar) {
 }
 
 configurations {
-    testOutput.extendsFrom (testCompile)
+    testOutput.extendsFrom (testImplementation)
 }
 
 artifacts.add('archives', sourcesJar)

--- a/imagepipeline-test/build.gradle
+++ b/imagepipeline-test/build.gradle
@@ -5,21 +5,21 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    compile project(':fbcore')
-    compile project(':imagepipeline-base')
-    compile project(':imagepipeline-base-test')
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
-    compile "junit:junit:${JUNIT_VERSION}"
-    compile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    compile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    api project(':imagepipeline-base-test')
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':fbcore')
+    implementation project(':imagepipeline-base')
+    implementation "junit:junit:${JUNIT_VERSION}"
+    implementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    implementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    compile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    compile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    compile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    implementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    implementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    implementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/imagepipeline/build.gradle
+++ b/imagepipeline/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
     implementation project(':fbcore')
 
+    testImplementation "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
     testImplementation "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     testImplementation project(':imagepipeline-test')
     testImplementation project(':imagepipeline-base-test')

--- a/samples/animation2/build.gradle
+++ b/samples/animation2/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 dependencies {
-    provided "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
 
-    compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
 
-    compile project(':animated-base')
-    compile project(':drawee-backends:drawee-pipeline')
+    implementation project(':animated-base')
+    implementation project(':drawee-backends:drawee-pipeline')
 
 }
 

--- a/samples/gestures/build.gradle
+++ b/samples/gestures/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile project(':drawee-backends:drawee-pipeline')
+    implementation project(':drawee-backends:drawee-pipeline')
 
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    testCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/samples/kotlin/build.gradle
+++ b/samples/kotlin/build.gradle
@@ -59,18 +59,18 @@ android {
 }
 
 dependencies {
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    provided "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
-    compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
-    compile "com.android.support:design:${SUPPORT_LIB_VERSION}"
-    compile "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
-    compile "com.android.support:cardview-v7:${SUPPORT_LIB_VERSION}"
-    compile "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${KOTLIN_VERSION}"
+    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:design:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:cardview-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"
 
-    compile project(':drawee-backends:drawee-pipeline')
-    compile project(':drawee-span')
-    compile project(':imagepipeline-backends:imagepipeline-okhttp3')
-    compile project(':tools:stetho')
-    compile project(path: ':imagepipeline-backends:imagepipeline-okhttp3')
+    implementation project(':drawee-backends:drawee-pipeline')
+    implementation project(':drawee-span')
+    implementation project(':imagepipeline-backends:imagepipeline-okhttp3')
+    implementation project(':tools:stetho')
+    implementation project(path: ':imagepipeline-backends:imagepipeline-okhttp3')
 }

--- a/samples/scrollperf/build.gradle
+++ b/samples/scrollperf/build.gradle
@@ -34,22 +34,24 @@ android {
 }
 
 dependencies {
-    compile project(':static-webp')
-    compile project(':drawee-backends:drawee-pipeline')
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
-    compile "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
-    compile "com.android.support:preference-v7:${SUPPORT_LIB_VERSION}"
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    androidTestCompile "junit:junit:${JUNIT_VERSION}"
-    androidTestCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
-    androidTestCompile("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
+    implementation project(':static-webp')
+    implementation project(':drawee-backends:drawee-pipeline')
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:recyclerview-v7:${SUPPORT_LIB_VERSION}"
+    implementation "com.android.support:preference-v7:${SUPPORT_LIB_VERSION}"
+
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+
+    androidTestImplementation "junit:junit:${JUNIT_VERSION}"
+    androidTestImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    androidTestImplementation("org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}") {
         exclude group: 'org.mockito', module: 'mockito-all'
     }
-    androidTestCompile "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
-    androidTestCompile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    androidTestCompile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    androidTestCompile("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
+    androidTestImplementation "org.powermock:powermock-module-junit4:${POWERMOCK_VERSION}"
+    androidTestImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    androidTestImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    androidTestImplementation("org.robolectric:robolectric:${ROBOLECTRIC_VERSION}") {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     }

--- a/samples/zoomable/build.gradle
+++ b/samples/zoomable/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.library'
 
 dependencies {
-    compile "com.nineoldandroids:library:${NINEOLDANDROID_VERSION}"
-    provided "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
-    provided "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
 
-    compile project(':drawee-backends:drawee-pipeline')
-    compile project(':samples:gestures')
+    implementation "com.nineoldandroids:library:${NINEOLDANDROID_VERSION}"
+    implementation project(':drawee-backends:drawee-pipeline')
+    implementation project(':samples:gestures')
 }
 
 android {

--- a/samples/zoomableapp/build.gradle
+++ b/samples/zoomableapp/build.gradle
@@ -51,6 +51,6 @@ dependencies {
     compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
     implementation "com.android.support:support-core-ui:${SUPPORT_LIB_VERSION}"
 
-    internalCompile project(':drawee-backends:drawee-pipeline')
+    internalImplementation project(':drawee-backends:drawee-pipeline')
     implementation project(path: ':samples:zoomable')
 }

--- a/static-webp/build.gradle
+++ b/static-webp/build.gradle
@@ -5,15 +5,18 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    compile "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
-    testCompile "junit:junit:${JUNIT_VERSION}"
-    androidTestCompile "junit:junit:${JUNIT_VERSION}"
-    androidTestCompile 'com.android.support.test:runner:0.4'
-    androidTestCompile 'com.android.support.test:rules:0.4'
-    compile project(':fbcore')
-    compile project(':imagepipeline-base')
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+
+    implementation "com.parse.bolts:bolts-tasks:${BOLTS_ANDROID_VERSION}"
+    implementation project(':fbcore')
+    implementation project(':imagepipeline-base')
+
+    testImplementation "junit:junit:${JUNIT_VERSION}"
+
+    androidTestImplementation "junit:junit:${JUNIT_VERSION}"
+    androidTestImplementation 'com.android.support.test:runner:0.4'
+    androidTestImplementation 'com.android.support.test:rules:0.4'
 }
 apply from: rootProject.file('release.gradle')
 

--- a/tools/stetho/build.gradle
+++ b/tools/stetho/build.gradle
@@ -5,14 +5,14 @@ project.group = GROUP
 version = VERSION_NAME
 
 dependencies {
-    provided "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
-    provided "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
-    compile "com.facebook.stetho:stetho:${STETHO_VERSION}"
+    compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
+    compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"
+    implementation "com.facebook.stetho:stetho:${STETHO_VERSION}"
 
-    compile project(':drawee-backends:drawee-pipeline')
-    compile project(':fbcore')
-    compile project(':imagepipeline')
-    compile project(':imagepipeline-base')
+    implementation project(':drawee-backends:drawee-pipeline')
+    implementation project(':fbcore')
+    implementation project(':imagepipeline')
+    implementation project(':imagepipeline-base')
 }
 
 apply from: rootProject.file('release.gradle')


### PR DESCRIPTION
## Motivation (required)

We were getting a lot of deprecation warnings when building with gradle after the update to 4.1. This PR switches all `provided` to `compileOnly` and `compile` to `implementation` / `api`, depending on the use case.

## Test Plan (required)

CI + run showcase app.