### PR TITLE
fix issue #2007 use getPostprocessedBitmapCacheKey replace getBitmapC…

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BitmapMemoryCacheProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/BitmapMemoryCacheProducer.java
@@ -49,7 +49,12 @@ public class BitmapMemoryCacheProducer implements Producer<CloseableReference<Cl
     listener.onProducerStart(requestId, getProducerName());
     final ImageRequest imageRequest = producerContext.getImageRequest();
     final Object callerContext = producerContext.getCallerContext();
-    final CacheKey cacheKey = mCacheKeyFactory.getBitmapCacheKey(imageRequest, callerContext);
+    final CacheKey cacheKey;
+    if (imageRequest.getPostprocessor() != null) {
+      cacheKey = mCacheKeyFactory.getPostprocessedBitmapCacheKey(imageRequest, callerContext);
+    } else {
+      cacheKey = mCacheKeyFactory.getBitmapCacheKey(imageRequest, callerContext);
+    }
 
     CloseableReference<CloseableImage> cachedReference = mMemoryCache.get(cacheKey);
 


### PR DESCRIPTION
fixed issue #2007

this should use `getPostprocessedBitmapCacheKey` when imageRequest.getPostProcessor() is not null.
