### PR TITLE
#1285 Fix webp with alpha decoding on API <= 17 devices

### DIFF
--- a/static-webp/src/main/jni/static-webp/webp_bitmapfactory.cpp
+++ b/static-webp/src/main/jni/static-webp/webp_bitmapfactory.cpp
@@ -145,7 +145,7 @@ jobject doDecode(
     return JNI_FALSE;
   }
 
-  config.output.colorspace = MODE_RGBA;
+  config.output.colorspace = MODE_rgbA;
   config.output.u.RGBA.rgba = (uint8_t*) raw_pixels;
   config.output.u.RGBA.stride = image_width * 4;
   config.output.u.RGBA.size = image_width * image_height * 4;


### PR DESCRIPTION
This PR aims to fix #1285 , because `doDecode` method in `webp_bitmapfactory.cpp` use the wrong colorspace to decode webp images on Android system.  `MODE_rgbA` should be used not `MODE_RGBA` and Bitmap is premultiplied by default. Thanks.