### PR TITLE
Do not treat response as partial with Content-Range if range includes…

### DIFF
--- a/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
+++ b/imagepipeline-backends/imagepipeline-okhttp3/src/main/java/com/facebook/imagepipeline/backends/okhttp3/OkHttpNetworkFetcher.java
@@ -39,6 +39,7 @@ public class OkHttpNetworkFetcher extends
     BaseNetworkFetcher<OkHttpNetworkFetcher.OkHttpNetworkFetchState> {
 
   public static class OkHttpNetworkFetchState extends FetchState {
+
     public long submitTime;
     public long responseTime;
     public long fetchCompleteTime;
@@ -137,7 +138,8 @@ public class OkHttpNetworkFetcher extends
               call.cancel();
             } else {
               mCancellationExecutor.execute(new Runnable() {
-                @Override public void run() {
+                @Override
+                public void run() {
                   call.cancel();
                 }
               });
@@ -162,7 +164,9 @@ public class OkHttpNetworkFetcher extends
 
               BytesRange responseRange =
                   BytesRange.fromContentRangeHeader(response.header("Content-Range"));
-              if (responseRange != null) {
+              if (responseRange != null &&
+                  !(responseRange.from == 0 && responseRange.to == BytesRange.TO_END_OF_CONTENT)) {
+                // Only treat as a partial image if the range is not all of the content
                 fetchState.setResponseBytesRange(responseRange);
                 fetchState.setOnNewResultStatusFlags(Consumer.IS_PARTIAL_RESULT);
               }


### PR DESCRIPTION
Do not treat the response as partial when "Content-Range" header is set if range includes the entire message.

## Motivation (required)

If the header "Content-Range" is ever passed in from a network request, the image will not be saved to cache. What I have changed is that, if "Content-Range" includes the entire content range for the image, then do not treat as a partial image.

## Test Plan (required)

I have tested this on my personal repo by trying to fetch an image with "Content-Range" set, but I have not created any unit tests.

  