### PR TITLE
E2E test for starting the Fresco Showcase app

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ test:
   override:
     - ./gradlew test assembleDebug -PdisablePreDex
     # start the emulator
-    - emulator -avd circleci-android22 -no-audio -no-window:
+    - emulator -avd circleci-android24 -no-window:
         background: true
         parallel: true
     # wait for it to have booted

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,21 @@ dependencies:
 test:
   override:
     - ./gradlew test assembleDebug -PdisablePreDex
+    # start the emulator
+    - emulator -avd circleci-android22 -no-audio -no-window:
+        background: true
+        parallel: true
+    # wait for it to have booted
+    - circle-android wait-for-boot
+    # unlock the emulator screen
+    - sleep 30
+    - adb shell input keyevent 82
+    # run tests  against the emulator.
+    - ./gradlew :samples:showcase:connectedMainDebugAndroidTest -PdisablePreDex
+    # copy the build outputs to artifacts
+    - cp -r app/build/outputs $CIRCLE_ARTIFACTS
+    # copy the test results to the test results directory.
+    - cp -r app/build/outputs/androidTest-results/* $CIRCLE_TEST_REPORTS
   post:
     # copy test report for Circle CI to display
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,10 @@
 machine:
   environment:
     PATH: $ANDROID_NDK:$PATH
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+    GRADLE_OPTS: '-Xmx512m -Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxPermSize=512m"'
+    ANDROID_BUILD_PATH: build/app-debug.apk
+    QEMU_AUDIO_DRV: none
+    _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
   java:
     version: oraclejdk8
 
@@ -17,18 +20,19 @@ dependencies:
 
 test:
   override:
-    - ./gradlew test assembleDebug -PdisablePreDex
     # start the emulator
-    - emulator -avd circleci-android24 -no-window:
-        background: true
-        parallel: true
+    - emulator -avd circleci-android21 -memory 512 -verbose -no-window -gpu swiftshader:
+         background: true
+         parallel: true
+    - android list avd
     # wait for it to have booted
     - circle-android wait-for-boot
     # unlock the emulator screen
     - sleep 30
     - adb shell input keyevent 82
     # run tests  against the emulator.
-    - ./gradlew :samples:showcase:connectedMainDebugAndroidTest -PdisablePreDex
+    - ./gradlew --stop
+    - ./gradlew :samples:showcase:connectedMainDebugAndroidTest -PdisablePreDex --no-daemon
     # copy the build outputs to artifacts
     - cp -r app/build/outputs $CIRCLE_ARTIFACTS
     # copy the test results to the test results directory.

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,7 @@
 machine:
   environment:
     PATH: $ANDROID_NDK:$PATH
-    GRADLE_OPTS: '-Xmx512m -Dorg.gradle.jvmargs="-Xmx512m -XX:+HeapDumpOnOutOfMemoryError -XX:MaxPermSize=512m"'
-    ANDROID_BUILD_PATH: build/app-debug.apk
-    QEMU_AUDIO_DRV: none
-    _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
   java:
     version: oraclejdk8
 
@@ -20,23 +17,7 @@ dependencies:
 
 test:
   override:
-    # start the emulator
-    - emulator -avd circleci-android21 -memory 512 -verbose -no-window -gpu swiftshader:
-         background: true
-         parallel: true
-    - android list avd
-    # wait for it to have booted
-    - circle-android wait-for-boot
-    # unlock the emulator screen
-    - sleep 30
-    - adb shell input keyevent 82
-    # run tests  against the emulator.
-    - ./gradlew --stop
-    - ./gradlew :samples:showcase:connectedMainDebugAndroidTest -PdisablePreDex --no-daemon
-    # copy the build outputs to artifacts
-    - cp -r app/build/outputs $CIRCLE_ARTIFACTS
-    # copy the test results to the test results directory.
-    - cp -r app/build/outputs/androidTest-results/* $CIRCLE_TEST_REPORTS
+    - ./gradlew test assembleDebug -PdisablePreDex
   post:
     # copy test report for Circle CI to display
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/

--- a/samples/showcase/build.gradle
+++ b/samples/showcase/build.gradle
@@ -77,4 +77,9 @@ dependencies {
 
     // Only used for the custom SVG decoder
     implementation 'com.caverock:androidsvg:1.2.1'
+
+    // Testing-only dependencies
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation "junit:junit:${JUNIT_VERSION}"
 }

--- a/samples/showcase/src/androidTest/java/com/facebook/fresco/samples/showcase/ShowcaseRunTest.java
+++ b/samples/showcase/src/androidTest/java/com/facebook/fresco/samples/showcase/ShowcaseRunTest.java
@@ -1,0 +1,45 @@
+/*
+ * This file provided by Facebook is for non-commercial testing and evaluation
+ * purposes only.  Facebook reserves all rights not expressly granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * FACEBOOK BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.facebook.fresco.samples.showcase;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.CoreMatchers.allOf;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.TextView;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ShowcaseRunTest {
+
+  @Rule
+  public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule(MainActivity.class);
+
+  @Test
+  public void testRunTheShowcaseApp() {
+    onView(withId(R.id.content_main)).check(matches(isDisplayed()));
+    onView(withId(R.id.toolbar)).check(matches(isDisplayed()));
+    onView(allOf(isAssignableFrom(TextView.class), withParent(withId(R.id.toolbar))))
+        .check(matches(withText(R.string.welcome_title)));
+  }
+}


### PR DESCRIPTION
Created an end to end test for running the showcase app on emulator, since there are currently no end to end tests for that.

Also modified the CircleCI config to run tests in there (based on https://github.com/circleci/EspressoSample/blob/master/circle.yml).

The test plan is to run the test locally:
`./gradlew :samples:showcase:connectedMainDebugAndroidTest -PdisablePreDex`

After submitting the PR we'll see if that works on CircleCI.
