### PR TITLE
Wikimedia commons app added to "Who uses Fresco"

### DIFF
--- a/docs/_data/powered_by.yml
+++ b/docs/_data/powered_by.yml
@@ -86,3 +86,5 @@
     url: https://play.google.com/store/apps/details?id=com.sitonmylab.picsforreddit
   - name: Apartment Buddy
     url: https://play.google.com/store/apps/details?id=com.apartmentbuddy.android
+  - name: Wikimedia Commons
+    url: https://play.google.com/store/apps/details?id=fr.free.nrw.commons


### PR DESCRIPTION
Fixes commons-app/apps-android-commons#1084

Wikimedia Commons app uses `Fresco`. Ready for review