### PR TITLE
switch to libwebp-0.6.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ LIBJPEG_TURBO_VERSION=1.5.0
 LIBPNG_VERSION=1.6.26
 GIFLIB_VERSION=5.1.1
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
-LIBWEBP_VERSION=0.6.0
+LIBWEBP_VERSION=0.6.1
 
 # SDK versions for the samples
 MIN_SDK_VERSION=9

--- a/static-webp/src/main/jni/static-webp/Android.mk
+++ b/static-webp/src/main/jni/static-webp/Android.mk
@@ -44,5 +44,5 @@ LOCAL_LDFLAGS += -Wl,--exclude-libs,libfb_png.a
 
 include $(BUILD_SHARED_LIBRARY)
 $(call import-module,libpng-1.6.26)
-$(call import-module,libwebp-0.6.0)
+$(call import-module,libwebp-0.6.1)
 $(call import-module,libjpeg-turbo-1.5.0)

--- a/static-webp/src/main/jni/third-party/libwebp-0.6.1/Android.mk
+++ b/static-webp/src/main/jni/third-party/libwebp-0.6.1/Android.mk
@@ -38,8 +38,6 @@ LOCAL_SRC_FILES := \
     src/dsp/alpha_processing_neon.$(NEON) \
     src/dsp/alpha_processing_sse2.c \
     src/dsp/alpha_processing_sse41.c \
-    src/dsp/argb.c \
-    src/dsp/argb_sse2.c \
     src/dsp/cpu.c \
     src/dsp/dec.c \
     src/dsp/dec_clip_tables.c \
@@ -59,6 +57,7 @@ LOCAL_SRC_FILES := \
     src/dsp/upsampling_neon.$(NEON) \
     src/dsp/upsampling_sse2.c \
     src/dsp/yuv.c \
+    src/dsp/yuv_neon.$(NEON) \
     src/dsp/yuv_sse2.c \
     src/utils/bit_reader_utils.c \
     src/utils/color_cache_utils.c \


### PR DESCRIPTION
Hello,
argb files have been removed from dsp/
https://github.com/webmproject/libwebp/commit/8acb4942f743933bf3b935cdd9cb1aed83dd2f6f#diff-51b4888dbb80cd444a36cfb9bcafb355
adapt static-webp/src/main/jni/third-party/libwebp-0.6.1/Android.mk to changes
