### PR TITLE
Default request timeout

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -80,6 +80,7 @@ public class ImagePipelineConfig {
   private final DiskCacheConfig mMainDiskCacheConfig;
   private final MemoryTrimmableRegistry mMemoryTrimmableRegistry;
   private final NetworkFetcher mNetworkFetcher;
+  private int mHttpNetworkTimeout = -1;
   @Nullable private final PlatformBitmapFactory mPlatformBitmapFactory;
   private final PoolFactory mPoolFactory;
   private final ProgressiveJpegConfig mProgressiveJpegConfig;
@@ -143,9 +144,13 @@ public class ImagePipelineConfig {
         builder.mMemoryTrimmableRegistry == null ?
             NoOpMemoryTrimmableRegistry.getInstance() :
             builder.mMemoryTrimmableRegistry;
+    mHttpNetworkTimeout =
+        builder.mHttpConnectionTimeout == -1 ?
+            HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT :
+            builder.mHttpConnectionTimeout;
     mNetworkFetcher =
         builder.mNetworkFetcher == null ?
-            new HttpUrlConnectionNetworkFetcher() :
+            new HttpUrlConnectionNetworkFetcher(mHttpNetworkTimeout) :
             builder.mNetworkFetcher;
     mPlatformBitmapFactory = builder.mPlatformBitmapFactory;
     mPoolFactory =
@@ -359,6 +364,7 @@ public class ImagePipelineConfig {
     private DiskCacheConfig mSmallImageDiskCacheConfig;
     private FileCacheFactory mFileCacheFactory;
     private ImageDecoderConfig mImageDecoderConfig;
+    private int mHttpConnectionTimeout = -1;
     private final ImagePipelineExperiments.Builder mExperimentsBuilder
         = new ImagePipelineExperiments.Builder(this);
 
@@ -387,6 +393,11 @@ public class ImagePipelineConfig {
 
     public Builder setCacheKeyFactory(CacheKeyFactory cacheKeyFactory) {
       mCacheKeyFactory = cacheKeyFactory;
+      return this;
+    }
+
+    public Builder setHttpConnectionTimeout(int httpConnectionTimeout) {
+      mHttpConnectionTimeout = httpConnectionTimeout;
       return this;
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -80,7 +80,7 @@ public class ImagePipelineConfig {
   private final DiskCacheConfig mMainDiskCacheConfig;
   private final MemoryTrimmableRegistry mMemoryTrimmableRegistry;
   private final NetworkFetcher mNetworkFetcher;
-  private int mHttpNetworkTimeout = -1;
+  private final int mHttpNetworkTimeout;
   @Nullable private final PlatformBitmapFactory mPlatformBitmapFactory;
   private final PoolFactory mPoolFactory;
   private final ProgressiveJpegConfig mProgressiveJpegConfig;
@@ -145,7 +145,7 @@ public class ImagePipelineConfig {
             NoOpMemoryTrimmableRegistry.getInstance() :
             builder.mMemoryTrimmableRegistry;
     mHttpNetworkTimeout =
-        builder.mHttpConnectionTimeout == -1 ?
+        builder.mHttpConnectionTimeout < 0 ?
             HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT :
             builder.mHttpConnectionTimeout;
     mNetworkFetcher =
@@ -396,8 +396,8 @@ public class ImagePipelineConfig {
       return this;
     }
 
-    public Builder setHttpConnectionTimeout(int httpConnectionTimeout) {
-      mHttpConnectionTimeout = httpConnectionTimeout;
+    public Builder setHttpConnectionTimeout(int httpConnectionTimeoutMs) {
+      mHttpConnectionTimeout = httpConnectionTimeoutMs;
       return this;
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
@@ -36,10 +36,17 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
 
   public static final int HTTP_DEFAULT_TIMEOUT = 30000;
 
+  private int mHttpConnectionTimeout;
+
   private final ExecutorService mExecutorService;
 
   public HttpUrlConnectionNetworkFetcher() {
     this(Executors.newFixedThreadPool(NUM_NETWORK_THREADS));
+  }
+
+  public HttpUrlConnectionNetworkFetcher(int httpConnectionTimeout) {
+    this(Executors.newFixedThreadPool(NUM_NETWORK_THREADS));
+    mHttpConnectionTimeout = httpConnectionTimeout;
   }
 
   @VisibleForTesting
@@ -102,7 +109,7 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
 
   private HttpURLConnection downloadFrom(Uri uri, int maxRedirects) throws IOException {
     HttpURLConnection connection = openConnectionTo(uri);
-    connection.setConnectTimeout(HTTP_DEFAULT_TIMEOUT);
+    connection.setConnectTimeout(mHttpConnectionTimeout);
     int responseCode = connection.getResponseCode();
 
     if (isHttpSuccess(responseCode)) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
@@ -34,6 +34,8 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
   public static final int HTTP_TEMPORARY_REDIRECT = 307;
   public static final int HTTP_PERMANENT_REDIRECT = 308;
 
+  public static final int HTTP_DEFAULT_TIMEOUT = 30000;
+
   private final ExecutorService mExecutorService;
 
   public HttpUrlConnectionNetworkFetcher() {
@@ -100,6 +102,7 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
 
   private HttpURLConnection downloadFrom(Uri uri, int maxRedirects) throws IOException {
     HttpURLConnection connection = openConnectionTo(uri);
+    connection.setConnectTimeout(HTTP_DEFAULT_TIMEOUT);
     int responseCode = connection.getResponseCode();
 
     if (isHttpSuccess(responseCode)) {
@@ -131,7 +134,7 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
   @VisibleForTesting
   static HttpURLConnection openConnectionTo(Uri uri) throws IOException {
     URL url = UriUtil.uriToUrl(uri);
-    return (HttpURLConnection) url.openConnection();
+    return (HttpURLConnection) url.openConnection().setConnectTimeout();
   }
 
   private static boolean isHttpSuccess(int responseCode) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcher.java
@@ -134,7 +134,7 @@ public class HttpUrlConnectionNetworkFetcher extends BaseNetworkFetcher<FetchSta
   @VisibleForTesting
   static HttpURLConnection openConnectionTo(Uri uri) throws IOException {
     URL url = UriUtil.uriToUrl(uri);
-    return (HttpURLConnection) url.openConnection().setConnectTimeout();
+    return (HttpURLConnection) url.openConnection();
   }
 
   private static boolean isHttpSuccess(int responseCode) {

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcherTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcherTest.java
@@ -195,6 +195,12 @@ public class HttpUrlConnectionNetworkFetcherTest {
     verifyNoMoreInteractions(mMockCallback);
   }
 
+  @Test
+  public void testHttpUrlConnectionTimeout() throws IOException {
+      HttpURLConnection mockRequest = mock(HttpURLConnection.class);
+      assert(mockRequest.getConnectTimeout() == HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT);
+  }
+
   private HttpURLConnection mockSuccess() throws IOException {
     return mockSuccessWithStream(mock(InputStream.class));
   }
@@ -206,6 +212,14 @@ public class HttpUrlConnectionNetworkFetcherTest {
 
     queueConnection(mockResponse);
 
+    return mockResponse;
+  }
+
+  private HttpURLConnection mockTimeout() throws IOException {
+    HttpURLConnection mockResponse = mock(HttpURLConnection.class);
+    when(mockResponse.getResponseCode()).thenReturn(408);
+
+    queueConnection(mockResponse);
     return mockResponse;
   }
 

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcherTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/HttpUrlConnectionNetworkFetcherTest.java
@@ -202,14 +202,14 @@ public class HttpUrlConnectionNetworkFetcherTest {
 
     URL mockURL = PowerMockito.mock(URL.class);
     HttpURLConnection mockConnection = PowerMockito.mock(HttpURLConnection.class);
-    mockConnection.setConnectTimeout(HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT);
+    mockConnection.setConnectTimeout(30000);
 
     PowerMockito.when(mockURL.openConnection()).thenReturn(mockConnection);
 
     SocketTimeoutException expectedException = new SocketTimeoutException();
     PowerMockito.when(mockConnection.getResponseCode()).thenThrow(expectedException);
 
-    verify(mockConnection).setConnectTimeout(HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT);
+    verify(mockConnection).setConnectTimeout(30000);
 
   }
 


### PR DESCRIPTION
## Motivation (required)
The motivation for this change comes from a problem in an app I'm working on, under very bad connectivity there was an issue where timeout meant the image wasn't being downloaded. After lots of testing and consideration to swap to a regular ImageView and download a Bitmap, I investigated further and found under the worst conditions it was taking 20 seconds to download the image.

What existing problem does the pull request solve?
It solves a timeout issue when downloading images over a weak or poor connection.

## Test Plan (required)
Unit test added to confirm connection timeout is set.
