### PR TITLE
[DropWebp] add enableDropFrame to webp play

### DIFF
--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResult.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResult.java
@@ -21,6 +21,7 @@ public class AnimatedImageResult {
 
   private final AnimatedImage mImage;
   private final int mFrameForPreview;
+  private final boolean mEnableDropFrame;
   private @Nullable CloseableReference<Bitmap> mPreviewBitmap;
   private @Nullable List<CloseableReference<Bitmap>> mDecodedFrames;
 
@@ -29,11 +30,13 @@ public class AnimatedImageResult {
     mFrameForPreview = builder.getFrameForPreview();
     mPreviewBitmap = builder.getPreviewBitmap();
     mDecodedFrames = builder.getDecodedFrames();
+    mEnableDropFrame = builder.getEnableDropFrame();
   }
 
   private AnimatedImageResult(AnimatedImage image) {
     mImage = Preconditions.checkNotNull(image);
     mFrameForPreview = 0;
+    mEnableDropFrame = false;
   }
 
   /**
@@ -110,6 +113,10 @@ public class AnimatedImageResult {
    */
   public synchronized CloseableReference<Bitmap> getPreviewBitmap() {
     return CloseableReference.cloneOrNull(mPreviewBitmap);
+  }
+
+  public boolean getEnableDropFrame() {
+    return mEnableDropFrame;
   }
 
   /**

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResultBuilder.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResultBuilder.java
@@ -20,6 +20,7 @@ public class AnimatedImageResultBuilder {
   private CloseableReference<Bitmap> mPreviewBitmap;
   private List<CloseableReference<Bitmap>> mDecodedFrames;
   private int mFrameForPreview;
+  private boolean mEnableDropFrame;
 
   AnimatedImageResultBuilder(AnimatedImage image) {
     mImage = image;
@@ -97,6 +98,15 @@ public class AnimatedImageResultBuilder {
       List<CloseableReference<Bitmap>> decodedFrames) {
     mDecodedFrames = CloseableReference.cloneOrNull(decodedFrames);
     return this;
+  }
+
+  public AnimatedImageResultBuilder setEnableDropFrame(boolean enable) {
+    mEnableDropFrame = enable;
+    return this;
+  }
+
+  public boolean getEnableDropFrame() {
+    return mEnableDropFrame;
   }
 
   /**

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
@@ -143,6 +143,7 @@ public class AnimatedImageFactoryImpl implements AnimatedImageFactory {
           .setPreviewBitmap(previewBitmap)
           .setFrameForPreview(frameForPreview)
           .setDecodedFrames(decodedFrames)
+          .setEnableDropFrame(options.enableDropFrame)
           .build();
       return new CloseableAnimatedImage(animatedImageResult);
     } finally {

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedFrameCache.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedFrameCache.java
@@ -52,7 +52,7 @@ public class AnimatedFrameCache {
       }
       if (o instanceof FrameKey) {
         FrameKey that = (FrameKey) o;
-        return this.mImageCacheKey == that.mImageCacheKey &&
+        return this.mImageCacheKey.equals(that.mImageCacheKey) &&
             this.mFrameIndex == that.mFrameIndex;
       }
       return false;

--- a/animated-base/src/main/java/com/facebook/imagepipeline/image/CloseableAnimatedImage.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/image/CloseableAnimatedImage.java
@@ -55,11 +55,6 @@ public class CloseableAnimatedImage extends CloseableImage {
     return isClosed() ? 0 : mImageResult.getImage().getSizeInBytes();
   }
 
-  @Override
-  public boolean isStateful() {
-    return true;
-  }
-
   public synchronized AnimatedImageResult getImageResult() {
     return mImageResult;
   }
@@ -67,4 +62,5 @@ public class CloseableAnimatedImage extends CloseableImage {
   public synchronized AnimatedImage getImage() {
     return isClosed() ? null : mImageResult.getImage();
   }
+
 }

--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/BitmapAnimationBackend.java
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/BitmapAnimationBackend.java
@@ -246,6 +246,9 @@ public class BitmapAnimationBackend implements AnimationBackend,
         case FRAME_TYPE_FALLBACK:
           bitmapReference = mBitmapFrameCache.getFallbackFrame(frameNumber);
           drawn = drawBitmapAndCache(frameNumber, bitmapReference, canvas, FRAME_TYPE_FALLBACK);
+          if (mEnableDropFrame) {
+            drawn = false;
+          }
           break;
 
         default:

--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/preparation/DropFramePreparationStrategy.java
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/preparation/DropFramePreparationStrategy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package com.facebook.fresco.animation.bitmap.preparation;
+
+import com.facebook.common.logging.FLog;
+import com.facebook.fresco.animation.backend.AnimationBackend;
+import com.facebook.fresco.animation.bitmap.BitmapFrameCache;
+
+/**
+ * Frame preparation strategy to prepare the next n frames
+ */
+public class DropFramePreparationStrategy
+    implements BitmapFramePreparationStrategy {
+
+  private static final Class<?> TAG = DropFramePreparationStrategy.class;
+
+  @Override
+  public void prepareFrames(
+      BitmapFramePreparer bitmapFramePreparer,
+      BitmapFrameCache bitmapFrameCache,
+      AnimationBackend animationBackend,
+      int lastDrawnFrameNumber) {
+      int nextFrameNumber = lastDrawnFrameNumber % animationBackend.getFrameCount();
+      if (FLog.isLoggable(FLog.VERBOSE)) {
+        FLog.v(TAG, "Preparing frame %d, last drawn: %d", nextFrameNumber, lastDrawnFrameNumber);
+      }
+      bitmapFramePreparer.prepareFrame(
+          bitmapFrameCache,
+          animationBackend,
+          nextFrameNumber);
+  }
+}

--- a/fbcore/src/main/java/com/facebook/common/executors/DropSerialExecutorService.java
+++ b/fbcore/src/main/java/com/facebook/common/executors/DropSerialExecutorService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.common.executors;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.PriorityBlockingQueue;
+
+/**
+ * Default implementation of {@link SerialExecutorService} that wraps an existing {@link Executor}.
+ */
+public class DropSerialExecutorService extends ConstrainedExecutorService
+    implements SerialExecutorService {
+
+  public DropSerialExecutorService(Executor executor) {
+    // SerialExecutorService is just a ConstrainedExecutorService with a concurrency limit
+    // of one and an unbounded work queue.
+    super("DropSerialExecutor", 1, executor, new PriorityBlockingQueue<Runnable>());
+  }
+
+  /**
+   * Synchronized override of {@link ConstrainedExecutorService#execute(Runnable)} to
+   * ensure that view of memory is consistent between different threads executing tasks serially.
+   * @param runnable The task to be executed.
+   */
+  @Override
+  public synchronized void execute(Runnable runnable) {
+    super.execute(runnable);
+  }
+}

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
@@ -22,7 +22,8 @@ public class AnimatedFactoryProvider {
   public static AnimatedFactory getAnimatedFactory(
       PlatformBitmapFactory platformBitmapFactory,
       ExecutorSupplier executorSupplier,
-      CountingMemoryCache<CacheKey, CloseableImage> backingCache) {
+      CountingMemoryCache<CacheKey, CloseableImage> backingCache,
+      CountingMemoryCache<CacheKey, CloseableImage> otherFrameCache) {
     if (!sImplLoaded) {
       try {
         final Class<?> clazz =
@@ -30,11 +31,13 @@ public class AnimatedFactoryProvider {
         final Constructor<?> constructor = clazz.getConstructor(
             PlatformBitmapFactory.class,
             ExecutorSupplier.class,
+            CountingMemoryCache.class,
             CountingMemoryCache.class);
         sImpl = (AnimatedFactory) constructor.newInstance(
             platformBitmapFactory,
             executorSupplier,
-            backingCache);
+            backingCache,
+            otherFrameCache);
       } catch (Throwable e) {
         // Head in the sand
       }

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptions.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptions.java
@@ -55,6 +55,8 @@ public class ImageDecodeOptions {
    */
   public final Bitmap.Config bitmapConfig;
 
+  public final boolean enableDropFrame;
+
   /**
    * Custom image decoder override.
    */
@@ -68,6 +70,7 @@ public class ImageDecodeOptions {
     this.forceStaticImage = b.getForceStaticImage();
     this.bitmapConfig = b.getBitmapConfig();
     this.customImageDecoder = b.getCustomImageDecoder();
+    this.enableDropFrame = b.getEnableDropFrame();
   }
 
   /**
@@ -101,6 +104,7 @@ public class ImageDecodeOptions {
     if (forceStaticImage != that.forceStaticImage) return false;
     if (bitmapConfig != that.bitmapConfig) return false;
     if (customImageDecoder != that.customImageDecoder) return false;
+    if (enableDropFrame != that.enableDropFrame) return false;
     return true;
   }
 
@@ -113,6 +117,7 @@ public class ImageDecodeOptions {
     result = 31 * result + (forceStaticImage ? 1 : 0);
     result = 31 * result + bitmapConfig.ordinal();
     result = 31 * result + (customImageDecoder != null ? customImageDecoder.hashCode() : 0);
+    result = 31 * result + (enableDropFrame ? 1 : 0);
     return result;
   }
 
@@ -120,13 +125,14 @@ public class ImageDecodeOptions {
   public String toString() {
     return String.format(
         (Locale) null,
-        "%d-%b-%b-%b-%b-%s-%s",
+        "%d-%b-%b-%b-%b-%s-%s-%b",
         minDecodeIntervalMs,
         decodePreviewFrame,
         useLastFrameForPreview,
         decodeAllFrames,
         forceStaticImage,
         bitmapConfig.name(),
-        customImageDecoder);
+        customImageDecoder,
+        enableDropFrame);
   }
 }

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptionsBuilder.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptionsBuilder.java
@@ -8,6 +8,7 @@
 package com.facebook.imagepipeline.common;
 
 import android.graphics.Bitmap;
+
 import com.facebook.imagepipeline.decoder.ImageDecoder;
 import javax.annotation.Nullable;
 
@@ -21,6 +22,7 @@ public class ImageDecodeOptionsBuilder {
   private boolean mUseLastFrameForPreview;
   private boolean mDecodeAllFrames;
   private boolean mForceStaticImage;
+  private boolean mEnableDropFrame;
   private Bitmap.Config mBitmapConfig = Bitmap.Config.ARGB_8888;
   private @Nullable ImageDecoder mCustomImageDecoder;
 
@@ -40,6 +42,7 @@ public class ImageDecodeOptionsBuilder {
     mForceStaticImage = options.forceStaticImage;
     mBitmapConfig = options.bitmapConfig;
     mCustomImageDecoder = options.customImageDecoder;
+    mEnableDropFrame = options.enableDropFrame;
     return this;
   }
 
@@ -190,6 +193,15 @@ public class ImageDecodeOptionsBuilder {
   public ImageDecodeOptionsBuilder setBitmapConfig(Bitmap.Config bitmapConfig) {
     mBitmapConfig = bitmapConfig;
     return this;
+  }
+
+  public ImageDecodeOptionsBuilder setEnableDropFrame(boolean enable) {
+    mEnableDropFrame = enable;
+    return this;
+  }
+
+  public boolean getEnableDropFrame() {
+    return mEnableDropFrame;
   }
 
   /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -359,7 +359,9 @@ public class ImagePipeline {
   public void evictFromMemoryCache(final Uri uri) {
     Predicate<CacheKey> predicate = predicateForUri(uri);
     mBitmapMemoryCache.removeAll(predicate);
-    mOtherFrameCache.removeAll(predicate);
+    if (mOtherFrameCache != null) {
+      mOtherFrameCache.removeAll(predicate);
+    }
     mEncodedMemoryCache.removeAll(predicate);
   }
 
@@ -410,7 +412,9 @@ public class ImagePipeline {
           }
         };
     mBitmapMemoryCache.removeAll(allPredicate);
-    mOtherFrameCache.removeAll(allPredicate);
+    if (mOtherFrameCache != null) {
+      mOtherFrameCache.removeAll(allPredicate);
+    }
     mEncodedMemoryCache.removeAll(allPredicate);
   }
 
@@ -441,8 +445,7 @@ public class ImagePipeline {
       return false;
     }
     Predicate<CacheKey> bitmapCachePredicate = predicateForUri(uri);
-    return mBitmapMemoryCache.contains(bitmapCachePredicate) ||
-            mOtherFrameCache.contains(bitmapCachePredicate);
+    return mBitmapMemoryCache.contains(bitmapCachePredicate);
   }
 
   /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipeline.java
@@ -54,6 +54,7 @@ public class ImagePipeline {
   private final RequestListener mRequestListener;
   private final Supplier<Boolean> mIsPrefetchEnabledSupplier;
   private final MemoryCache<CacheKey, CloseableImage> mBitmapMemoryCache;
+  private final MemoryCache<CacheKey, CloseableImage> mOtherFrameCache;
   private final MemoryCache<CacheKey, PooledByteBuffer> mEncodedMemoryCache;
   private final BufferedDiskCache mMainBufferedDiskCache;
   private final BufferedDiskCache mSmallImageBufferedDiskCache;
@@ -69,6 +70,7 @@ public class ImagePipeline {
       Supplier<Boolean> isPrefetchEnabledSupplier,
       MemoryCache<CacheKey, CloseableImage> bitmapMemoryCache,
       MemoryCache<CacheKey, PooledByteBuffer> encodedMemoryCache,
+      MemoryCache<CacheKey, CloseableImage> otherMemoryCache,
       BufferedDiskCache mainBufferedDiskCache,
       BufferedDiskCache smallImageBufferedDiskCache,
       CacheKeyFactory cacheKeyFactory,
@@ -80,6 +82,7 @@ public class ImagePipeline {
     mRequestListener = new ForwardingRequestListener(requestListeners);
     mIsPrefetchEnabledSupplier = isPrefetchEnabledSupplier;
     mBitmapMemoryCache = bitmapMemoryCache;
+    mOtherFrameCache = otherMemoryCache;
     mEncodedMemoryCache = encodedMemoryCache;
     mMainBufferedDiskCache = mainBufferedDiskCache;
     mSmallImageBufferedDiskCache = smallImageBufferedDiskCache;
@@ -356,6 +359,7 @@ public class ImagePipeline {
   public void evictFromMemoryCache(final Uri uri) {
     Predicate<CacheKey> predicate = predicateForUri(uri);
     mBitmapMemoryCache.removeAll(predicate);
+    mOtherFrameCache.removeAll(predicate);
     mEncodedMemoryCache.removeAll(predicate);
   }
 
@@ -406,6 +410,7 @@ public class ImagePipeline {
           }
         };
     mBitmapMemoryCache.removeAll(allPredicate);
+    mOtherFrameCache.removeAll(allPredicate);
     mEncodedMemoryCache.removeAll(allPredicate);
   }
 
@@ -436,7 +441,8 @@ public class ImagePipeline {
       return false;
     }
     Predicate<CacheKey> bitmapCachePredicate = predicateForUri(uri);
-    return mBitmapMemoryCache.contains(bitmapCachePredicate);
+    return mBitmapMemoryCache.contains(bitmapCachePredicate) ||
+            mOtherFrameCache.contains(bitmapCachePredicate);
   }
 
   /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -67,6 +67,7 @@ public class ImagePipelineConfig {
   // There are a lot of parameters in this class. Please follow strict alphabetical order.
   private final Bitmap.Config mBitmapConfig;
   private final Supplier<MemoryCacheParams> mBitmapMemoryCacheParamsSupplier;
+  private final Supplier<MemoryCacheParams> mOtherFrameMemoryCacheParamsSupplier;
   private final CountingMemoryCache.CacheTrimStrategy mBitmapMemoryCacheTrimStrategy;
   private final CacheKeyFactory mCacheKeyFactory;
   private final Context mContext;
@@ -101,6 +102,11 @@ public class ImagePipelineConfig {
             new DefaultBitmapMemoryCacheParamsSupplier(
                 (ActivityManager) builder.mContext.getSystemService(Context.ACTIVITY_SERVICE)) :
             builder.mBitmapMemoryCacheParamsSupplier;
+    mOtherFrameMemoryCacheParamsSupplier =
+            builder.mOtherMemoryCacheParamsSupplier == null ?
+                    new DefaultBitmapMemoryCacheParamsSupplier(
+                            (ActivityManager) builder.mContext.getSystemService(Context.ACTIVITY_SERVICE)) :
+                    builder.mOtherMemoryCacheParamsSupplier;
     mBitmapMemoryCacheTrimStrategy =
         builder.mBitmapMemoryCacheTrimStrategy == null ?
             new BitmapMemoryCacheTrimStrategy() :
@@ -226,6 +232,10 @@ public class ImagePipelineConfig {
     return mBitmapMemoryCacheParamsSupplier;
   }
 
+  public Supplier<MemoryCacheParams> getOtherFrameCacheParamsSupplier() {
+    return mOtherFrameMemoryCacheParamsSupplier;
+  }
+
   public CountingMemoryCache.CacheTrimStrategy getBitmapMemoryCacheTrimStrategy() {
     return mBitmapMemoryCacheTrimStrategy;
   }
@@ -344,6 +354,7 @@ public class ImagePipelineConfig {
 
     private Bitmap.Config mBitmapConfig;
     private Supplier<MemoryCacheParams> mBitmapMemoryCacheParamsSupplier;
+    private Supplier<MemoryCacheParams> mOtherMemoryCacheParamsSupplier;
     private CountingMemoryCache.CacheTrimStrategy mBitmapMemoryCacheTrimStrategy;
     private CacheKeyFactory mCacheKeyFactory;
     private final Context mContext;
@@ -382,6 +393,13 @@ public class ImagePipelineConfig {
         Supplier<MemoryCacheParams> bitmapMemoryCacheParamsSupplier) {
       mBitmapMemoryCacheParamsSupplier =
           Preconditions.checkNotNull(bitmapMemoryCacheParamsSupplier);
+      return this;
+    }
+
+    public Builder setOtherFrameMemoryCacheParamsSupplier(
+            Supplier<MemoryCacheParams> bitmapMemoryCacheParamsSupplier) {
+      mOtherMemoryCacheParamsSupplier =
+              Preconditions.checkNotNull(bitmapMemoryCacheParamsSupplier);
       return this;
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -99,6 +99,8 @@ public class ImagePipelineFactory {
   private final ImagePipelineConfig mConfig;
   private CountingMemoryCache<CacheKey, CloseableImage>
       mBitmapCountingMemoryCache;
+  private CountingMemoryCache<CacheKey, CloseableImage>
+      mOtherFrameCountingMemoryCahce;
   private MemoryCache<CacheKey, CloseableImage> mBitmapMemoryCache;
   private CountingMemoryCache<CacheKey, PooledByteBuffer> mEncodedCountingMemoryCache;
   private MemoryCache<CacheKey, PooledByteBuffer> mEncodedMemoryCache;
@@ -129,7 +131,8 @@ public class ImagePipelineFactory {
       mAnimatedFactory = AnimatedFactoryProvider.getAnimatedFactory(
           getPlatformBitmapFactory(),
           mConfig.getExecutorSupplier(),
-          getBitmapCountingMemoryCache());
+          getBitmapCountingMemoryCache(),
+          getOtherFrameCountingMemoryCache());
     }
     return mAnimatedFactory;
   }
@@ -152,6 +155,20 @@ public class ImagePipelineFactory {
               mConfig.getBitmapMemoryCacheTrimStrategy());
     }
     return mBitmapCountingMemoryCache;
+  }
+
+  public CountingMemoryCache<CacheKey, CloseableImage>
+  getOtherFrameCountingMemoryCache() {
+    if (mOtherFrameCountingMemoryCahce == null) {
+      mOtherFrameCountingMemoryCahce =
+              BitmapCountingMemoryCacheFactory.get(
+                      mConfig.getOtherFrameCacheParamsSupplier(),
+                      mConfig.getMemoryTrimmableRegistry(),
+                      getPlatformBitmapFactory(),
+                      mConfig.getExperiments().isExternalCreatedBitmapLogEnabled(),
+                      mConfig.getBitmapMemoryCacheTrimStrategy());
+    }
+    return mOtherFrameCountingMemoryCahce;
   }
 
   public MemoryCache<CacheKey, CloseableImage> getBitmapMemoryCache() {
@@ -252,6 +269,7 @@ public class ImagePipelineFactory {
               mConfig.getIsPrefetchEnabledSupplier(),
               getBitmapMemoryCache(),
               getEncodedMemoryCache(),
+              getOtherFrameCountingMemoryCache(),
               getMainBufferedDiskCache(),
               getSmallImageBufferedDiskCache(),
               mConfig.getCacheKeyFactory(),

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapPool.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapPool.java
@@ -9,6 +9,7 @@ package com.facebook.imagepipeline.memory;
 
 import android.annotation.TargetApi;
 import android.graphics.Bitmap;
+
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.memory.MemoryTrimmableRegistry;
 import com.facebook.imageutils.BitmapUtil;

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ImagePipelineTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/core/ImagePipelineTest.java
@@ -95,6 +95,7 @@ public class ImagePipelineTest {
         mPrefetchEnabledSupplier,
         mBitmapMemoryCache,
         mEncodedMemoryCache,
+        null,
         mMainDiskStorageCache,
         mSmallImageDiskStorageCache,
         mCacheKeyFactory,

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/MainActivity.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/MainActivity.java
@@ -47,6 +47,7 @@ import com.facebook.fresco.samples.showcase.imageformat.override.ImageFormatOver
 import com.facebook.fresco.samples.showcase.imageformat.pjpeg.ImageFormatProgressiveJpegFragment;
 import com.facebook.fresco.samples.showcase.imageformat.svg.ImageFormatSvgFragment;
 import com.facebook.fresco.samples.showcase.imageformat.webp.ImageFormatWebpFragment;
+import com.facebook.fresco.samples.showcase.imageformat.webplist.ImageFormatWebpListFragment;
 import com.facebook.fresco.samples.showcase.imagepipeline.ImagePipelineBitmapFactoryFragment;
 import com.facebook.fresco.samples.showcase.imagepipeline.ImagePipelineNotificationFragment;
 import com.facebook.fresco.samples.showcase.imagepipeline.ImagePipelinePostProcessorFragment;
@@ -220,6 +221,9 @@ public class MainActivity extends AppCompatActivity
         break;
       case R.id.nav_format_webp:
         fragment = new ImageFormatWebpFragment();
+        break;
+      case R.id.nav_format_webp_list:
+        fragment = new ImageFormatWebpListFragment();
         break;
       case R.id.nav_format_svg:
         fragment = new ImageFormatSvgFragment();

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.java
@@ -20,6 +20,7 @@ import com.facebook.drawee.backends.pipeline.DraweeConfig;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.fresco.samples.showcase.misc.DebugOverlaySupplierSingleton;
 import com.facebook.imagepipeline.backends.okhttp3.OkHttpImagePipelineConfigFactory;
+import com.facebook.imagepipeline.cache.MemoryCacheParams;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.imagepipeline.decoder.SimpleProgressiveJpegConfig;
 import com.facebook.imagepipeline.listener.RequestListener;
@@ -51,6 +52,7 @@ public class ShowcaseApplication extends Application {
 
     ImagePipelineConfig imagePipelineConfig =
         OkHttpImagePipelineConfigFactory.newBuilder(this, okHttpClient)
+            .setOtherFrameMemoryCacheParamsSupplier(getOtherMemSupper())
             .setRequestListeners(listeners)
             .setProgressiveJpegConfig(new SimpleProgressiveJpegConfig())
             .setImageDecoderConfig(CustomImageFormatConfigurator.createImageDecoderConfig(this))
@@ -92,5 +94,22 @@ public class ShowcaseApplication extends Application {
                 })
             .enableWebKitInspector(Stetho.defaultInspectorModulesProvider(context))
             .build());
+  }
+
+  /**
+   * config for the webp(Exclude frame 0)
+   */
+  private Supplier<MemoryCacheParams> getOtherMemSupper() {
+    return new Supplier<MemoryCacheParams>() {
+      @Override
+      public MemoryCacheParams get() {
+        return new MemoryCacheParams(
+                (int) Runtime.getRuntime().maxMemory() / 8,
+                Integer.MAX_VALUE,
+                (int) Runtime.getRuntime().maxMemory() / 16,
+                300,
+                Integer.MAX_VALUE);
+      }
+    };
   }
 }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/ImageFormatWebpListFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/ImageFormatWebpListFragment.java
@@ -1,0 +1,57 @@
+package com.facebook.fresco.samples.showcase.imageformat.webplist;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SwitchCompat;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.fresco.samples.showcase.BaseShowcaseFragment;
+import com.facebook.fresco.samples.showcase.R;
+import com.facebook.fresco.samples.showcase.imageformat.webplist.controller.SwitchController;
+import com.facebook.fresco.samples.showcase.imageformat.webplist.controller.WebpListController;
+
+/**
+ * This Fragment is used to display a large number of webp pictures in a list
+ * will appear to be stuck while sliding.
+ */
+public class ImageFormatWebpListFragment extends BaseShowcaseFragment implements
+        SwitchController.OnEnableChangeListener {
+
+  private WebpListController mListController;
+
+  @Nullable
+  @Override
+  public View onCreateView(
+          @NonNull LayoutInflater inflater,
+          @Nullable ViewGroup container,
+          @Nullable Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.framgent_format_webp_list,
+            container, false);
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    mListController = new WebpListController((RecyclerView) view.findViewById(R.id.rcy_webp_list));
+    SwitchController dropFrameController = new SwitchController(
+            (SwitchCompat) view.findViewById(R.id.sw_enable_drop_frame));
+
+    mListController.bindData();
+    dropFrameController.setDropChangeListener(this);
+  }
+
+  @Override
+  public int getTitleId() {
+    return R.string.format_webp_list_title;
+  }
+
+  @Override
+  public void onDropChanged(boolean enable) {
+    if (mListController != null) {
+      mListController.onDropChanged(enable);
+    }
+  }
+}

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/adapter/WebpAdapter.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/adapter/WebpAdapter.java
@@ -1,0 +1,88 @@
+package com.facebook.fresco.samples.showcase.imageformat.webplist.adapter;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.drawee.interfaces.DraweeController;
+import com.facebook.drawee.view.SimpleDraweeView;
+import com.facebook.fresco.samples.showcase.R;
+import com.facebook.fresco.samples.showcase.misc.ImageUriProvider;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
+
+/**
+ * The Adapter for the webp list;
+ * In this example, only one webp is playing. For privacy reasons, the webp list I use cannot
+ * be uploaded. You can add more webp items to show the problem of Stuck.
+ */
+public class WebpAdapter extends RecyclerView.Adapter<WebpAdapter.WebpViewHolder> {
+
+  private static final int MAX_SIZE = 10000;
+
+  private volatile boolean mEnableDropFrame = false;
+
+  @NonNull
+  @Override
+  public WebpViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+    return new WebpViewHolder(LayoutInflater.from(parent.getContext())
+            .inflate(R.layout.item_rcy_webp, parent, false),
+            mEnableDropFrame);
+  }
+
+  @Override
+  public void onBindViewHolder(@NonNull WebpViewHolder holder, int position) {
+    holder.bind(position);
+  }
+
+  @Override
+  public int getItemCount() {
+    return MAX_SIZE;
+  }
+
+  public void setEnableDropFrame(boolean enableDropped) {
+    mEnableDropFrame = enableDropped;
+  }
+
+  static class WebpViewHolder extends RecyclerView.ViewHolder {
+
+    private final ImageUriProvider imageUriProvider;
+
+    private SimpleDraweeView mWebpIv;
+    private TextView mTitleTv;
+    private String mShowText;
+    private boolean mEnableDrop;
+
+    WebpViewHolder(View itemView, boolean enableDrop) {
+      super(itemView);
+      mTitleTv = itemView.findViewById(R.id.tv_webp_title);
+      mWebpIv = itemView.findViewById(R.id.iv_webp);
+      imageUriProvider = ImageUriProvider.getInstance(itemView.getContext());
+      mEnableDrop = enableDrop;
+    }
+
+    void bind(int position) {
+      mShowText = "Pos_" + position;
+      mTitleTv.setText(mShowText);
+
+      Uri uri = imageUriProvider.createWebpAnimatedUri();
+      DraweeController controller = Fresco.newDraweeControllerBuilder()
+              .setImageRequest(
+                    ImageRequestBuilder.newBuilderWithSource(uri)
+                        .setImageDecodeOptions(
+                              ImageDecodeOptions.newBuilder()
+                              .setEnableDropFrame(mEnableDrop)
+                              .build())
+                    .build())
+              .setOldController(mWebpIv.getController())
+              .setAutoPlayAnimations(true)
+              .build();
+      mWebpIv.setController(controller);
+    }
+  }
+}

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/controller/SwitchController.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/controller/SwitchController.java
@@ -1,0 +1,35 @@
+package com.facebook.fresco.samples.showcase.imageformat.webplist.controller;
+
+import android.support.v7.widget.SwitchCompat;
+import android.widget.CompoundButton;
+
+/**
+ * The Switch to change Normal/Drop
+ * Normal : the webp playback is more complete, but it may too cause stuck.
+ * Drop : the playback may drop some frame, but no stuck.
+ */
+public class SwitchController implements CompoundButton.OnCheckedChangeListener {
+
+  private boolean mEnable;
+  private OnEnableChangeListener mChangeListener;
+
+  public SwitchController(SwitchCompat switchCompat) {
+    switchCompat.setOnCheckedChangeListener(this);
+  }
+
+  public void setDropChangeListener(OnEnableChangeListener listener) {
+    mChangeListener = listener;
+  }
+
+  @Override
+  public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+    if (mEnable != isChecked && mChangeListener != null) {
+      mChangeListener.onDropChanged(isChecked);
+    }
+    mEnable = isChecked;
+  }
+
+  public interface OnEnableChangeListener {
+    void onDropChanged(boolean enableDropped);
+  }
+}

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/controller/WebpListController.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/controller/WebpListController.java
@@ -1,0 +1,26 @@
+package com.facebook.fresco.samples.showcase.imageformat.webplist.controller;
+
+import android.support.v7.widget.RecyclerView;
+
+import com.facebook.fresco.samples.showcase.imageformat.webplist.adapter.WebpAdapter;
+import com.facebook.fresco.samples.showcase.imageformat.webplist.utils.RecyclerListUtil;
+
+public class WebpListController {
+
+  private RecyclerView mWebpListRcy;
+
+  public WebpListController(RecyclerView recyclerView) {
+    mWebpListRcy = recyclerView;
+  }
+
+  public void bindData() {
+    RecyclerListUtil.bindData(mWebpListRcy, new WebpAdapter());
+  }
+
+  public void onDropChanged(boolean enableDropped) {
+    WebpAdapter adapter = new WebpAdapter();
+    adapter.setEnableDropFrame(enableDropped);
+    RecyclerListUtil.bindData(mWebpListRcy, adapter);
+  }
+
+}

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/utils/RecyclerListUtil.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webplist/utils/RecyclerListUtil.java
@@ -1,0 +1,16 @@
+package com.facebook.fresco.samples.showcase.imageformat.webplist.utils;
+
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.StaggeredGridLayoutManager;
+
+public class RecyclerListUtil {
+
+  public static void bindData(RecyclerView view, RecyclerView.Adapter adapter) {
+    view.setHasFixedSize(true);
+    view.setItemAnimator(null);
+    view.setLayoutManager(new StaggeredGridLayoutManager(4,
+            RecyclerView.VERTICAL));
+    view.setAdapter(adapter);
+  }
+
+}

--- a/samples/showcase/src/main/res/layout/framgent_format_webp_list.xml
+++ b/samples/showcase/src/main/res/layout/framgent_format_webp_list.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+        <android.support.v7.widget.SwitchCompat
+            android:id="@+id/sw_enable_drop_frame"
+            android:text="@string/format_name_webp_list_drop_enable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            />
+
+    </LinearLayout>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rcy_webp_list"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+</LinearLayout>

--- a/samples/showcase/src/main/res/layout/item_rcy_webp.xml
+++ b/samples/showcase/src/main/res/layout/item_rcy_webp.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="140dp"
+    >
+
+    <com.facebook.drawee.view.SimpleDraweeView
+        android:id="@+id/iv_webp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+    <TextView
+        android:id="@+id/tv_webp_title"
+        android:layout_gravity="center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        />
+
+</FrameLayout>

--- a/samples/showcase/src/main/res/menu/activity_main_drawer.xml
+++ b/samples/showcase/src/main/res/menu/activity_main_drawer.xml
@@ -118,6 +118,10 @@
             android:title="@string/format_webp_title"
             />
         <item
+            android:id="@+id/nav_format_webp_list"
+            android:title="@string/format_webp_list_title"
+            />
+        <item
             android:id="@+id/nav_format_svg"
             android:title="@string/format_svg_title"
             />

--- a/samples/showcase/src/main/res/values/strings.xml
+++ b/samples/showcase/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
   <string name="format_webp_translucent_help">The above Drawee displays a loss-less WebP image with semi-transparent areas.</string>
   <string name="format_webp_animated_help">The above Drawee displays an animated WebP image</string>
 
+  <string name="format_webp_list_title">WebP List</string>
+
   <string name="format_pjpeg_title">Progressive JPEG</string>
   <string name="format_pjpeg_help">Select a progressive JPEG from the spinner and enable or disable progessive JPEG support with the switch.</string>
   <string name="format_pjpeg_switch_rendering_enabled">Progressive JPEG rendering enabled</string>
@@ -228,6 +230,7 @@
   <string name="format_name_png_landscape">PNG landscape</string>
   <string name="format_name_png_portrait">PNG portrait</string>
   <string name="format_name_webp">WebP</string>
+  <string name="format_name_webp_list_drop_enable">Drop frame</string>
   <string name="format_name_animated_webp">animated WebP</string>
   <string name="format_name_translucent_webp">translucent WebP</string>
 


### PR DESCRIPTION
The redesign of #2110  . @oprisnik 
I modified the following code:
1. ImageDecodeOption add enableDropFrame flag. After this flag is turned on, there is no guarantee that WebP will play on time, but it will certainly not stuck the UI thread.
2. Storage aspects. When enableDropFrame is set, the first frame and other frames exist in different caches. The first frame is along with Fresco's BitmapCache, while the other frames are together. This is done to ensure that the first frame comes out in time.
3. Control aspects. When enableDropFrame is set, only the current frame to be drawn is prepared in the background. If the current frame is not drawn correctly, the frame will be drawn next time.
4. WebP result will be cached. 
5. Add a fragment to display the WebP list.