### PR TITLE
Set bitmap to canvas before translating canvas

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/bitmaps/PlatformBitmapFactory.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/bitmaps/PlatformBitmapFactory.java
@@ -312,7 +312,7 @@ public abstract class PlatformBitmapFactory {
     int newWidth = width;
     int newHeight = height;
 
-    Canvas canvas = new Canvas();
+    Canvas canvas;
     CloseableReference<Bitmap> bitmapRef;
     Paint paint;
 
@@ -322,6 +322,8 @@ public abstract class PlatformBitmapFactory {
 
     if (matrix == null || matrix.isIdentity()) {
       bitmapRef = createBitmap(newWidth, newHeight, newConfig, source.hasAlpha(), callerContext);
+      setPropertyFromSourceBitmap(source, bitmapRef.get());
+      canvas = new Canvas(bitmapRef.get());
       paint = null;   // not needed
     } else {
       boolean transformed = !matrix.rectStaysRect();
@@ -338,6 +340,8 @@ public abstract class PlatformBitmapFactory {
               transformed || source.hasAlpha(),
               callerContext);
 
+      setPropertyFromSourceBitmap(source, bitmapRef.get());
+      canvas = new Canvas(bitmapRef.get());
       canvas.translate(-deviceRectangle.left, -deviceRectangle.top);
       canvas.concat(matrix);
 
@@ -348,20 +352,6 @@ public abstract class PlatformBitmapFactory {
       }
     }
 
-    // The new bitmap was created from a known bitmap source so assume that
-    // they use the same density
-    Bitmap bitmap = bitmapRef.get();
-    bitmap.setDensity(source.getDensity());
-
-    if (Build.VERSION.SDK_INT >= 12) {
-      bitmap.setHasAlpha(source.hasAlpha());
-    }
-
-    if (Build.VERSION.SDK_INT >= 19) {
-      bitmap.setPremultiplied(source.isPremultiplied());
-    }
-
-    canvas.setBitmap(bitmap);
     canvas.drawBitmap(source, srcRectangle, dstRectangle, paint);
     canvas.setBitmap(null);
 
@@ -753,6 +743,26 @@ public abstract class PlatformBitmapFactory {
     Preconditions.checkArgument(
         y + height <= source.getHeight(),
         "y + height must be <= bitmap.height()");
+  }
+
+  /**
+   * Set some property of the source bitmap to the destination bitmap
+   *
+   *
+   * @param source the source bitmap
+   * @param destination the destination bitmap
+   */
+  private static void setPropertyFromSourceBitmap(Bitmap source, Bitmap destination) {
+    // The new bitmap was created from a known bitmap source so assume that
+    // they use the same density
+    destination.setDensity(source.getDensity());
+    if (Build.VERSION.SDK_INT >= 12) {
+      destination.setHasAlpha(source.hasAlpha());
+    }
+
+    if (Build.VERSION.SDK_INT >= 19) {
+      destination.setPremultiplied(source.isPremultiplied());
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation (required)

On Android Oreo and building with target SDK 26 or above, `PlatformBitmapFactory#createScaledBitmap` doesn't work correctly.
Because, `Canvas#setBitmap` behavior was changed on SDK 26. Calling setBitmap causes reset translation of canvas.
So, we should call setBitmap before translating canvas.

This behavior changes are mentioned at javadoc of `Canvas#setBitmap`
ref: https://github.com/aosp-mirror/platform_frameworks_base/blob/oreo-release/graphics/java/android/graphics/Canvas.java#L160-L172

## Test Plan (required)

Tested on Sample app on target SDK 26 and Oreo device

||original|scaling|
|:--:|:--:|:--:|
|before|![api_26_original_before](https://user-images.githubusercontent.com/7804631/40522318-40515a14-600b-11e8-88a2-627a126ce8a4.png)|![api_26_scaling_before](https://user-images.githubusercontent.com/7804631/40522324-4515abae-600b-11e8-8d4c-e5e3c952f999.png)|
|fixed|![api_26_original_after](https://user-images.githubusercontent.com/7804631/40522329-4b6fcb9c-600b-11e8-800c-bb90e62d3826.png)|![api_26_scaling_after](https://user-images.githubusercontent.com/7804631/40522336-50917fc6-600b-11e8-850d-bdfdfa31889f.png)|

