### PR TITLE
Fixed #2122 - PooledByteBuffer.read() doesn't return int

### DIFF
--- a/fbcore/src/main/java/com/facebook/common/memory/PooledByteBuffer.java
+++ b/fbcore/src/main/java/com/facebook/common/memory/PooledByteBuffer.java
@@ -37,7 +37,7 @@ public interface PooledByteBuffer extends Closeable {
    * @param length number of bytes to copy
    * @return number of bytes copied
    */
-  void read(int offset, byte[] buffer, int bufferOffset, int length);
+  int read(int offset, byte[] buffer, int bufferOffset, int length);
 
   /**
    * @return pointer to native memory backing this buffer

--- a/imagepipeline-base-test/src/main/java/com/facebook/imagepipeline/testing/TrivialPooledByteBuffer.java
+++ b/imagepipeline-base-test/src/main/java/com/facebook/imagepipeline/testing/TrivialPooledByteBuffer.java
@@ -36,8 +36,9 @@ public class TrivialPooledByteBuffer implements PooledByteBuffer {
   }
 
   @Override
-  public void read(int offset, byte[] buffer, int bufferOffset, int length) {
+  public int read(int offset, byte[] buffer, int bufferOffset, int length) {
     System.arraycopy(mBuf, offset, buffer, bufferOffset, length);
+    return length;
   }
 
   @Override

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/NativePooledByteBuffer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/NativePooledByteBuffer.java
@@ -54,12 +54,12 @@ public class NativePooledByteBuffer implements PooledByteBuffer {
   }
 
   @Override
-  public synchronized void read(int offset, byte[] buffer, int bufferOffset, int length) {
+  public synchronized int read(int offset, byte[] buffer, int bufferOffset, int length) {
     ensureValid();
     // We need to make sure that PooledByteBuffer's length is preserved.
     // Al the other bounds checks will be performed by NativeMemoryChunk.read method.
     Preconditions.checkArgument(offset + length <= mSize);
-    mBufRef.get().read(offset, buffer, bufferOffset, length);
+    return mBufRef.get().read(offset, buffer, bufferOffset, length);
   }
 
   @Override


### PR DESCRIPTION
## Motivation (required)

This pull request fixed #2122 by changing com.facebook.common.memory.PooledByteBuffer#read(int, byte[], int, int) to make it return int, and its implementation com.facebook.imagepipeline.memory.NativePooledByteBuffer.

## Test Plan (required)

It should test when compile passed
