### PR TITLE
GIF images can now be scaled to the container size using fit_XY.

### DIFF
--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableBackendImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableBackendImpl.java
@@ -67,8 +67,8 @@ public class AnimatedDrawableBackendImpl implements AnimatedDrawableBackend {
     return new Rect(
         0,
         0,
-        Math.min(targetBounds.width(), image.getWidth()),
-        Math.min(targetBounds.height(), image.getHeight()));
+        image.getWidth(),
+        image.getHeight());
   }
 
   @Override

--- a/animated-gif/src/main/jni/Application.mk
+++ b/animated-gif/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 # Copyright 2004-present Facebook. All Rights Reserved.
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a armeabi arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)../../../nativedeps/merge

--- a/imagepipeline/src/main/jni/Application.mk
+++ b/imagepipeline/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 # Copyright 2004-present Facebook. All Rights Reserved.
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a armeabi arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)../../../nativedeps/merge

--- a/static-webp/src/main/jni/Application.mk
+++ b/static-webp/src/main/jni/Application.mk
@@ -1,7 +1,7 @@
 # Copyright 2004-present Facebook. All Rights Reserved.
 APP_BUILD_SCRIPT := Android.mk
 
-APP_ABI := armeabi-v7a armeabi arm64-v8a x86 x86_64
+APP_ABI := armeabi-v7a arm64-v8a x86 x86_64
 
 APP_MK_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 NDK_MODULE_PATH := $(APP_MK_DIR)$(HOST_DIRSEP)$(APP_MK_DIR)../../../nativedeps/merge


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch

## Motivation (required)
Solves the fit_XY problem that was previously detected on issue #2067

## Test Plan (required)

A good example of this problem is seen on Simple DraweeSpan on showcase sample included in this library.