### PR TITLE
[ScaleType] add parallax scale type

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/drawable/ScalingUtils.java
+++ b/drawee/src/main/java/com/facebook/drawee/drawable/ScalingUtils.java
@@ -90,6 +90,12 @@ public class ScalingUtils {
     ScaleType FIT_BOTTOM_START = ScaleTypeFitBottomStart.INSTANCE;
 
     /**
+     * Scales the child so that it can be used in a parallax animation. When the wrapper View slide
+     * horizontally or vertically, the inner image can also parallax move.
+     */
+    ScaleType PARALLAX = ScaleTypeParallax.INSTANCE;
+
+    /**
      * Gets transformation matrix based on the scale type.
      *
      * @param outTransform out matrix to store result
@@ -380,6 +386,45 @@ public class ScalingUtils {
     @Override
     public String toString() {
       return "center_crop";
+    }
+  }
+
+  private static class ScaleTypeParallax extends AbstractScaleType {
+
+    public static final ScaleType INSTANCE = new ScaleTypeParallax();
+
+    private float mParallaxFactor = 1.2f;
+
+    /**
+     * set the parallax factor to the Drawable.
+     * @param factor the parallax factor to config the the image's off-screen size
+     */
+    public void setParallaxFactor(float factor) {
+      mParallaxFactor = factor;
+    }
+
+    @Override
+    public void getTransformImpl(
+            Matrix outTransform,
+            Rect parentRect,
+            int childWidth,
+            int childHeight,
+            float focusX,
+            float focusY,
+            float scaleX,
+            float scaleY) {
+      float scale = Math.max(scaleX, scaleY) * mParallaxFactor;
+      float parallaxTotalX = parentRect.width() / scale - childWidth;
+      float parallaxTotalY = parentRect.height() / scale - childHeight;
+      float dx = focusX * parallaxTotalX;
+      float dy = focusY * parallaxTotalY;
+      outTransform.setScale(scale, scale);
+      outTransform.preTranslate((int) (dx + 0.5f), (int) (dy + 0.5f));
+    }
+
+    @Override
+    public String toString() {
+      return "parallax";
     }
   }
 

--- a/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
@@ -208,4 +208,9 @@ public class SimpleDraweeView extends GenericDraweeView {
   public void setImageResource(int resId) {
     super.setImageResource(resId);
   }
+
+  @Override
+  public boolean performClick() {
+    return super.performClick();
+  }
 }

--- a/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
@@ -209,8 +209,4 @@ public class SimpleDraweeView extends GenericDraweeView {
     super.setImageResource(resId);
   }
 
-  @Override
-  public boolean performClick() {
-    return super.performClick();
-  }
 }

--- a/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/SimpleDraweeView.java
@@ -208,5 +208,4 @@ public class SimpleDraweeView extends GenericDraweeView {
   public void setImageResource(int resId) {
     super.setImageResource(resId);
   }
-
 }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/common/SimpleScaleTypeAdapter.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/common/SimpleScaleTypeAdapter.java
@@ -35,7 +35,8 @@ public class SimpleScaleTypeAdapter extends BaseAdapter {
       new Entry(ScalingUtils.ScaleType.FIT_END, "fit_end", null),
       new Entry(ScalingUtils.ScaleType.FIT_XY, "fit_xy", null),
       new Entry(ScalingUtils.ScaleType.FOCUS_CROP, "focus_crop (0, 0)", new PointF(0, 0)),
-      new Entry(ScalingUtils.ScaleType.FOCUS_CROP, "focus_crop (1, 0.5)", new PointF(1, 0.5f))
+      new Entry(ScalingUtils.ScaleType.FOCUS_CROP, "focus_crop (1, 0.5)", new PointF(1, 0.5f)),
+      new Entry(ScalingUtils.ScaleType.PARALLAX, "parallax,touch image", new PointF(0.5f, 0.5f))
   };
 
   private static final Entry[] CUSTOM_TYPES = new Entry[]{


### PR DESCRIPTION
## Motivation (required)
The material design image type. Refers to https://material.io/design/material-studies/basil.html.
Make it easy to have a parallax image animation.

## Test Plan (required)

set the scale-type to PARALLAX.

## Demo
![hor](https://user-images.githubusercontent.com/8406296/41599914-0b950b62-7407-11e8-90f2-85de1152171d.gif)

![ver](https://user-images.githubusercontent.com/8406296/41599917-10425584-7407-11e8-84a0-2cd72c574898.gif)

