### PR TITLE
[FIX] fix below androidN, the preActivity's DraweeView can't detach when startActivity

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
+++ b/drawee/src/main/java/com/facebook/drawee/view/DraweeView.java
@@ -283,14 +283,18 @@ public class DraweeView<DH extends DraweeHierarchy> extends ImageView {
       View changedView,
       int visibility) {
     super.onVisibilityChanged(changedView, visibility);
-    maybeOverrideVisibilityHandling();
+    maybeOverrideVisibilityHandling(visibility);
   }
 
   private void maybeOverrideVisibilityHandling() {
+    maybeOverrideVisibilityHandling(getVisibility());
+  }
+
+  private void maybeOverrideVisibilityHandling(int visibility) {
     if (mLegacyVisibilityHandlingEnabled)  {
       Drawable drawable = getDrawable();
       if (drawable != null) {
-        drawable.setVisible(getVisibility() == VISIBLE, false);
+        drawable.setVisible(visibility == VISIBLE, false);
       }
     }
   }


### PR DESCRIPTION
## Motivation (required)

Below Android N, the preActivity's DraweeView can't detach when startActivity. When we startActivity, the PhoneWindow#DecorView invoke onVisibilityChanged(), but at that time getVisiblity() is not equal with the changing visibility. For example, when we startActivity, visibility is going to INVISIBLE but getVisibility() in maybeOverrideVisibilityHandling() is returning VISIBLE.

## Test Plan (required)

Use a phone which API is below N, startActivity to another Acitivity and watch the preActivity's DraweeView has detached or not.
