### PR TITLE
Add image‘s origin info to DebugControllerOverlayDrawable

### DIFF
--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
@@ -23,6 +23,7 @@ import com.facebook.drawee.backends.pipeline.info.ForwardingImageOriginListener;
 import com.facebook.drawee.backends.pipeline.info.ImageOrigin;
 import com.facebook.drawee.backends.pipeline.info.ImageOriginListener;
 import com.facebook.drawee.backends.pipeline.info.ImageOriginRequestListener;
+import com.facebook.drawee.backends.pipeline.info.ImageOriginUtils;
 import com.facebook.drawee.backends.pipeline.info.ImagePerfDataListener;
 import com.facebook.drawee.backends.pipeline.info.ImagePerfMonitor;
 import com.facebook.drawee.components.DeferredReleaser;
@@ -85,6 +86,7 @@ public class PipelineDraweeController
   @GuardedBy("this")
   @Nullable
   private ImageOriginListener mImageOriginListener;
+  private int mImageOrigin = ImageOrigin.UNKNOWN;
 
   public PipelineDraweeController(
       Resources resources,
@@ -121,6 +123,7 @@ public class PipelineDraweeController
     mCacheKey = cacheKey;
     setCustomDrawableFactories(customDrawableFactories);
     clearImageOriginListeners();
+    maybeUpdateDebugOverlay(null);
     addImageOriginListener(imageOriginListener);
   }
 
@@ -290,11 +293,22 @@ public class PipelineDraweeController
     }
 
     if (getControllerOverlay() == null) {
-      DebugControllerOverlayDrawable controllerOverlay = new DebugControllerOverlayDrawable();
+      final DebugControllerOverlayDrawable controllerOverlay = new DebugControllerOverlayDrawable();
       ImageLoadingTimeControllerListener overlayImageLoadListener =
           new ImageLoadingTimeControllerListener(controllerOverlay);
       addControllerListener(overlayImageLoadListener);
       setControllerOverlay(controllerOverlay);
+    }
+
+    if (mImageOriginListener == null) {
+      ImageOriginListener overlayImageOriginListener = new ImageOriginListener() {
+        @Override
+        public void onImageLoaded(String controllerId, int imageOrigin, boolean successful) {
+          mImageOrigin = imageOrigin;
+
+        }
+      };
+      addImageOriginListener(overlayImageOriginListener);
     }
 
     if (getControllerOverlay() instanceof DebugControllerOverlayDrawable) {
@@ -310,6 +324,7 @@ public class PipelineDraweeController
         scaleType = scaleTypeDrawable != null ? scaleTypeDrawable.getScaleType() : null;
       }
       debugOverlay.setScaleType(scaleType);
+      debugOverlay.setOrigin(ImageOriginUtils.toString(mImageOrigin));
       if (image != null) {
         debugOverlay.setDimensions(image.getWidth(), image.getHeight());
         debugOverlay.setImageSize(image.getSizeInBytes());

--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/info/ForwardingImageOriginListener.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/info/ForwardingImageOriginListener.java
@@ -40,10 +40,12 @@ public class ForwardingImageOriginListener implements ImageOriginListener {
     final int numberOfListeners = mImageOriginListeners.size();
     for (int i = 0; i < numberOfListeners; i++) {
       ImageOriginListener listener = mImageOriginListeners.get(i);
-      try {
-        listener.onImageLoaded(controllerId, imageOrigin, successful);
-      } catch (Exception e) {
-        FLog.e(TAG, "InternalListener exception in onImageLoaded", e);
+      if (listener != null) {
+        try {
+          listener.onImageLoaded(controllerId, imageOrigin, successful);
+        } catch (Exception e) {
+          FLog.e(TAG, "InternalListener exception in onImageLoaded", e);
+        }
       }
     }
   }

--- a/drawee/src/main/java/com/facebook/drawee/debug/DebugControllerOverlayDrawable.java
+++ b/drawee/src/main/java/com/facebook/drawee/debug/DebugControllerOverlayDrawable.java
@@ -45,13 +45,13 @@ public class DebugControllerOverlayDrawable extends Drawable implements ImageLoa
   private static final int TEXT_COLOR = 0xFFFFFFFF;
   private static final int OUTLINE_STROKE_WIDTH_PX = 2;
   private static final int MAX_TEXT_SIZE_PX = 40;
-  private static final int MIN_TEXT_SIZE_PX = 12;
+  private static final int MIN_TEXT_SIZE_PX = 10;
   private static final int TEXT_LINE_SPACING_PX = 8;
   private static final int TEXT_PADDING_PX = 10;
 
   // Debug-text dependent parameters
-  private static final int MAX_NUMBER_OF_LINES = 7;
-  private static final int MAX_LINE_WIDTH_EM = 7;
+  private static final int MAX_NUMBER_OF_LINES = 9;
+  private static final int MAX_LINE_WIDTH_EM = 8;
 
   // General information
   private String mControllerId;
@@ -82,6 +82,7 @@ public class DebugControllerOverlayDrawable extends Drawable implements ImageLoa
   private int mCurrentTextYPx;
 
   private long mFinalImageTimeMs;
+  private String mOrigin;
 
   public DebugControllerOverlayDrawable() {
     reset();
@@ -96,6 +97,7 @@ public class DebugControllerOverlayDrawable extends Drawable implements ImageLoa
     mImageFormat = null;
     setControllerId(null);
     mFinalImageTimeMs = -1;
+    mOrigin = null;
     invalidateSelf();
   }
 
@@ -130,6 +132,11 @@ public class DebugControllerOverlayDrawable extends Drawable implements ImageLoa
   public void setAnimationInfo(int frameCount, int loopCount) {
     mFrameCount = frameCount;
     mLoopCount = loopCount;
+    invalidateSelf();
+  }
+
+  public void setOrigin(String s) {
+    mOrigin = s;
     invalidateSelf();
   }
 
@@ -201,6 +208,9 @@ public class DebugControllerOverlayDrawable extends Drawable implements ImageLoa
     }
     if (mFinalImageTimeMs >= 0) {
       addDebugText(canvas, "t: %d ms", mFinalImageTimeMs);
+    }
+    if (mOrigin != null) {
+      addDebugText(canvas, "origin: %s", mOrigin);
     }
   }
 


### PR DESCRIPTION
## Motivation
if many images display on screen, too many logs output. It's hard to debug an image is in memory cache or disk cache. If the DebugControllerOverlayDrawable show this info will be helpful.

## Test Plan
<img width="206" alt="sfafs" src="https://user-images.githubusercontent.com/3580391/43150324-35183a9e-8f9c-11e8-83a4-bdeb40046dbd.png">
