### PR TITLE
libwebp updated to 1.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ LIBJPEG_TURBO_VERSION=1.5.0
 LIBPNG_VERSION=1.6.35
 GIFLIB_VERSION=5.1.4
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
-LIBWEBP_VERSION=0.6.1
+LIBWEBP_VERSION=1.0.0
 
 # SDK versions for the samples
 MIN_SDK_VERSION=9

--- a/static-webp/src/main/jni/static-webp/Android.mk
+++ b/static-webp/src/main/jni/static-webp/Android.mk
@@ -44,5 +44,5 @@ LOCAL_LDFLAGS += -Wl,--exclude-libs,libfb_png.a
 
 include $(BUILD_SHARED_LIBRARY)
 $(call import-module,libpng-1.6.35)
-$(call import-module,libwebp-0.6.1)
+$(call import-module,libwebp-1.0.0)
 $(call import-module,libjpeg-turbo-1.5.0)

--- a/static-webp/src/main/jni/third-party/libwebp-1.0.0/Android.mk
+++ b/static-webp/src/main/jni/third-party/libwebp-1.0.0/Android.mk
@@ -56,9 +56,11 @@ LOCAL_SRC_FILES := \
     src/dsp/upsampling.c \
     src/dsp/upsampling_neon.$(NEON) \
     src/dsp/upsampling_sse2.c \
+    src/dsp/upsampling_sse41.c \
     src/dsp/yuv.c \
     src/dsp/yuv_neon.$(NEON) \
     src/dsp/yuv_sse2.c \
+    src/dsp/yuv_sse41.c \
     src/utils/bit_reader_utils.c \
     src/utils/color_cache_utils.c \
     src/utils/filters_utils.c \


### PR DESCRIPTION
## Motivation (required)
Our security check tool found the CVE problem in libwebp.
I think it was a false positive as the related problem was fixed on 0.5.2.

It is up to you to decide if it worth it to update to 1.0.0.

## Test Plan (required)
Make sure that unit tests pass.