### PR TITLE
Proper support for GIFs when using a RetainingDataSource

### DIFF
--- a/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
+++ b/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
@@ -321,7 +321,7 @@ public abstract class AbstractDataSource<T> implements DataSource<T> {
   }
 
   @Override
-  public boolean isReadyToPlay() {
+  public boolean hasMultipleResults() {
     return false;
   }
 }

--- a/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
+++ b/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
@@ -319,4 +319,9 @@ public abstract class AbstractDataSource<T> implements DataSource<T> {
           });
     }
   }
+
+  @Override
+  public boolean isReadyToPlay() {
+    return false;
+  }
 }

--- a/fbcore/src/main/java/com/facebook/datasource/DataSource.java
+++ b/fbcore/src/main/java/com/facebook/datasource/DataSource.java
@@ -54,7 +54,7 @@ public interface DataSource<T> {
    * @return true if any resources poured in the datasource should be sent to controllers. Usefull
    * with a RetainingDataSource to loaded resources are displayed correctly.
    */
-  boolean isReadyToPlay();
+  boolean hasMultipleResults();
 
   /**
    * @return true if request is finished, false otherwise

--- a/fbcore/src/main/java/com/facebook/datasource/DataSource.java
+++ b/fbcore/src/main/java/com/facebook/datasource/DataSource.java
@@ -50,6 +50,13 @@ public interface DataSource<T> {
   boolean hasResult();
 
   /**
+   *
+   * @return true if any resources poured in the datasource should be sent to controllers. Usefull
+   * with a RetainingDataSource to loaded resources are displayed correctly.
+   */
+  boolean isReadyToPlay();
+
+  /**
    * @return true if request is finished, false otherwise
    */
   boolean isFinished();

--- a/fbcore/src/main/java/com/facebook/datasource/RetainingDataSourceSupplier.java
+++ b/fbcore/src/main/java/com/facebook/datasource/RetainingDataSourceSupplier.java
@@ -139,5 +139,10 @@ public class RetainingDataSourceSupplier<T> implements Supplier<DataSource<T>> {
         RetainingDataSource.this.onDatasourceProgress(dataSource);
       }
     }
+
+    @Override
+    public boolean isReadyToPlay() {
+      return true;
+    }
   }
 }

--- a/fbcore/src/main/java/com/facebook/datasource/RetainingDataSourceSupplier.java
+++ b/fbcore/src/main/java/com/facebook/datasource/RetainingDataSourceSupplier.java
@@ -141,7 +141,7 @@ public class RetainingDataSourceSupplier<T> implements Supplier<DataSource<T>> {
     }
 
     @Override
-    public boolean isReadyToPlay() {
+    public boolean hasMultipleResults() {
       return true;
     }
   }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/RetainingDataSourceSupplierFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/RetainingDataSourceSupplierFragment.java
@@ -11,27 +11,25 @@
  */
 package com.facebook.fresco.samples.showcase.drawee;
 
-import android.graphics.drawable.Animatable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.RetainingDataSourceSupplier;
 import com.facebook.drawee.backends.pipeline.Fresco;
-import com.facebook.drawee.controller.BaseControllerListener;
-import com.facebook.drawee.controller.ControllerListener;
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.facebook.fresco.samples.showcase.BaseShowcaseFragment;
 import com.facebook.fresco.samples.showcase.R;
 import com.facebook.fresco.samples.showcase.misc.ImageUriProvider;
 import com.facebook.imagepipeline.image.CloseableImage;
-import com.facebook.imagepipeline.image.ImageInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
-
+import android.graphics.drawable.Animatable;
+import com.facebook.imagepipeline.image.ImageInfo;
+import com.facebook.drawee.controller.BaseControllerListener;
+import com.facebook.drawee.controller.ControllerListener;
 import java.util.List;
 
 public class RetainingDataSourceSupplierFragment extends BaseShowcaseFragment {

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/RetainingDataSourceSupplierFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/drawee/RetainingDataSourceSupplierFragment.java
@@ -11,21 +11,27 @@
  */
 package com.facebook.fresco.samples.showcase.drawee;
 
+import android.graphics.drawable.Animatable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.RetainingDataSourceSupplier;
 import com.facebook.drawee.backends.pipeline.Fresco;
+import com.facebook.drawee.controller.BaseControllerListener;
+import com.facebook.drawee.controller.ControllerListener;
 import com.facebook.drawee.view.SimpleDraweeView;
 import com.facebook.fresco.samples.showcase.BaseShowcaseFragment;
 import com.facebook.fresco.samples.showcase.R;
 import com.facebook.fresco.samples.showcase.misc.ImageUriProvider;
 import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.ImageInfo;
 import com.facebook.imagepipeline.request.ImageRequest;
+
 import java.util.List;
 
 public class RetainingDataSourceSupplierFragment extends BaseShowcaseFragment {
@@ -33,12 +39,24 @@ public class RetainingDataSourceSupplierFragment extends BaseShowcaseFragment {
   private List<Uri> mSampleUris;
   private int mUriIndex = 0;
 
+  private ControllerListener controllerListener = new BaseControllerListener<ImageInfo>() {
+    @Override
+    public void onFinalImageSet(
+            String id,
+            @Nullable ImageInfo imageInfo,
+            @Nullable Animatable anim) {
+      if (anim != null) {
+        // app-specific logic to enable animation starting
+        anim.start();
+      }
+    }
+  };
+
   @Override
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
-    mSampleUris =
-        ImageUriProvider.getInstance(getContext()).getSampleUris(ImageUriProvider.ImageSize.M);
+    mSampleUris = ImageUriProvider.getInstance(getContext()).getSampleGifUris();
   }
 
   @Nullable
@@ -54,7 +72,10 @@ public class RetainingDataSourceSupplierFragment extends BaseShowcaseFragment {
     final RetainingDataSourceSupplier<CloseableReference<CloseableImage>> retainingSupplier =
         new RetainingDataSourceSupplier<>();
     simpleDraweeView.setController(
-        Fresco.newDraweeControllerBuilder().setDataSourceSupplier(retainingSupplier).build());
+        Fresco.newDraweeControllerBuilder()
+                .setDataSourceSupplier(retainingSupplier)
+                .setControllerListener(controllerListener)
+                .build());
     replaceImage(retainingSupplier);
     simpleDraweeView.setOnClickListener(
         new View.OnClickListener() {

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/misc/ImageUriProvider.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/misc/ImageUriProvider.java
@@ -146,6 +146,13 @@ public class ImageUriProvider {
   private static final String SAMPLE_URI_WEBP_ANIMATED =
       "https://www.gstatic.com/webp/animated/1.webp";
 
+  private static final String[] SAMPLE_URIS_GIFS =
+          new String [] {
+            "https://media2.giphy.com/media/3oge84qhopFbFFkwec/giphy.gif",
+            "https://media3.giphy.com/media/uegrGBitPHtKM/giphy.gif",
+            "https://media0.giphy.com/media/SWd9mTHEMIxQ4/giphy.gif"
+          };
+
   private static ImageUriProvider sInstance;
 
   private final SharedPreferences mSharedPreferences;
@@ -277,6 +284,14 @@ public class ImageUriProvider {
       data.add(Uri.parse(String.format((Locale) null, uriFormat, imageId)));
     }
     return data;
+  }
+
+  public List<Uri> getSampleGifUris(){
+    ArrayList<Uri> uris = new ArrayList<>();
+    for (String uri : SAMPLE_URIS_GIFS) {
+      uris.add(Uri.parse(uri));
+    }
+    return uris;
   }
 
   private Uri applyOverrideSettings(


### PR DESCRIPTION
## Motivation (required)
During the development of the Giphy app we choose to use fresco as our main image library. The application loads different types of image renditions, starting from low-quality images to high-quality ones. We wanted to be able to change the quality of a GIF displayed in a `DraweeView`.

When making a simple request to change the resource of a `DraweeView`, fresco will clear the current content, display the placeholder, then load the new resource. Even with the resources preloaded, there is a noticeable flickering.

Available solutions:
1. Use a low-res/hi-res schema for loading images. Unfortunately, in this schema, the low-res image is not animated.
2. Use a `RetainingDataSource`. While it's purpose was exactly what we were looking for, it turns out that this data source, does it's magic by lying to the `AbstractDataSource` code and keeping it in a forever `PROGRESS` state. That means, the datasource will never get to notify the listening controllers. This is the reason GIFs are not playing and controller callbacks are not fired using this `DataSource`.

## Test Plan (required)
Given a list of GIFs, by using a `RetainingDataSource` we should be able to replace the current playing view with a freshly loaded one, without the user notice any flickering or blank spaces between the 2 resouces.

I've created a set of test GIFS in the `ImageUriProvider` and I updated the `RetainingDataSourceSupplierFragment` to use those resouces, in order to demonstrate the new achieved behaviour.

**Demo video:**
https://youtu.be/A67X6Vn9VjY