### PR TITLE
Add support for windows ico image format

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormatChecker.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormatChecker.java
@@ -32,6 +32,7 @@ public class DefaultImageFormatChecker implements ImageFormat.FormatChecker {
           PNG_HEADER_LENGTH,
           GIF_HEADER_LENGTH,
           BMP_HEADER_LENGTH,
+          ICO_HEADER_LENGTH,
           HEIF_HEADER_LENGTH);
 
   @Override
@@ -70,6 +71,10 @@ public class DefaultImageFormatChecker implements ImageFormat.FormatChecker {
 
     if (isBmpHeader(headerBytes, headerSize)) {
       return DefaultImageFormats.BMP;
+    }
+
+    if (isIcoHeader(headerBytes, headerSize)) {
+      return DefaultImageFormats.ICO;
     }
 
     if (isHeifHeader(headerBytes, headerSize)) {
@@ -209,6 +214,27 @@ public class DefaultImageFormatChecker implements ImageFormat.FormatChecker {
       return false;
     }
     return ImageFormatCheckerUtils.startsWithPattern(imageHeaderBytes, BMP_HEADER);
+  }
+
+  /**
+   * Every ico image starts with 0x00000100 bytes
+   */
+  private static final byte[] ICO_HEADER = new byte[]{(byte)0x00, (byte)0x00, (byte)0x01, (byte)0x00};
+  private static final int ICO_HEADER_LENGTH = ICO_HEADER.length;
+
+  /**
+   * Checks if first headerSize bytes of imageHeaderBytes constitute a valid header for a ico image.
+   * Details on ICO header can be found <a href="https://en.wikipedia.org/wiki/ICO_(file_format)">
+   * </a>
+   * @param imageHeaderBytes
+   * @param headerSize
+   * @return true if imageHeaderBytes is a valid header for a ico image
+   */
+  private static boolean isIcoHeader(final byte[] imageHeaderBytes, final int headerSize) {
+    if (headerSize < ICO_HEADER.length) {
+      return false;
+    }
+    return ImageFormatCheckerUtils.startsWithPattern(imageHeaderBytes, ICO_HEADER);
   }
 
   /**

--- a/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormats.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormats.java
@@ -19,6 +19,7 @@ public final class DefaultImageFormats {
   public static final ImageFormat PNG = new ImageFormat("PNG", "png");
   public static final ImageFormat GIF = new ImageFormat("GIF", "gif");
   public static final ImageFormat BMP = new ImageFormat("BMP", "bmp");
+  public static final ImageFormat ICO = new ImageFormat("ICO", "ico");
   public static final ImageFormat WEBP_SIMPLE = new ImageFormat("WEBP_SIMPLE", "webp");
   public static final ImageFormat WEBP_LOSSLESS = new ImageFormat("WEBP_LOSSLESS", "webp");
   public static final ImageFormat WEBP_EXTENDED = new ImageFormat("WEBP_EXTENDED", "webp");
@@ -66,6 +67,7 @@ public final class DefaultImageFormats {
       mDefaultFormats.add(PNG);
       mDefaultFormats.add(GIF);
       mDefaultFormats.add(BMP);
+      mDefaultFormats.add(ICO);
       mDefaultFormats.add(WEBP_SIMPLE);
       mDefaultFormats.add(WEBP_LOSSLESS);
       mDefaultFormats.add(WEBP_EXTENDED);


### PR DESCRIPTION
## Motivation

There is some case we need load .ico format image to SimpleDraweeView and BitmapFactory support decode this format on Android System but fresco not support. Though we can write our own CustomDecoder and config it into fresco, we expect the fresco could support it natively. This can be achieved by only add a little code in `DefaultImageFormatChecker`. 

## Test Plan

http://static.iqiyi.com/ext/common/ffb4f4483feb4c78b9cb74b7eee8d5d3.ico  This ico file can be used for test. It works well on my devices.
