### PR TITLE
Do not cache unknown format images to EncodedMemoryCache

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/EncodedMemoryCacheProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/EncodedMemoryCacheProducer.java
@@ -11,6 +11,7 @@ import com.facebook.cache.common.CacheKey;
 import com.facebook.common.internal.ImmutableMap;
 import com.facebook.common.memory.PooledByteBuffer;
 import com.facebook.common.references.CloseableReference;
+import com.facebook.imageformat.ImageFormat;
 import com.facebook.imagepipeline.cache.CacheKeyFactory;
 import com.facebook.imagepipeline.cache.MemoryCache;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -126,9 +127,11 @@ public class EncodedMemoryCacheProducer implements Producer<EncodedImage> {
       try {
         FrescoSystrace.beginSection("EncodedMemoryCacheProducer#onNewResultImpl");
         // intermediate, null or uncacheable results are not cached, so we just forward them
+        // as well as the images with unknown format which could be html response from the server
         if (isNotLast(status)
             || newResult == null
-            || statusHasAnyFlag(status, DO_NOT_CACHE_ENCODED | IS_PARTIAL_RESULT)) {
+            || statusHasAnyFlag(status, DO_NOT_CACHE_ENCODED | IS_PARTIAL_RESULT)
+                || newResult.getImageFormat() == ImageFormat.UNKNOWN) {
           getConsumer().onNewResult(newResult, status);
           return;
         }


### PR DESCRIPTION
## Motivation (required)

optimize #1413 #675 

BUG reproduce step：
1. connect to a Portal WiFi, we got a HTTP 200 code and html response. fresco cache the data to EncodedMemoryCache
2. user login the wifi or change to another connectable WIFI and enter the page again, the image still can not be load success due to the wrong memory cache hit.
3. user must restart the app or  browse other more pictures to trim the corrupt data from memory cache, then it will restore to normal status.

To optimize the user experience, we should not cache the unknown image format data to EncodedMemoryCache. Once the network become available, the image will reload success.


