### PR TITLE
Add support to decode android resources to Drawable directly

### DIFF
--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DefaultDrawableFactory.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DefaultDrawableFactory.java
@@ -13,6 +13,7 @@ import android.graphics.drawable.Drawable;
 import android.media.ExifInterface;
 import com.facebook.drawee.drawable.OrientedDrawable;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
+import com.facebook.imagepipeline.image.CloseableDrawable;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.CloseableStaticBitmap;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -54,6 +55,9 @@ public class DefaultDrawableFactory implements DrawableFactory {
               closeableStaticBitmap.getRotationAngle(),
               closeableStaticBitmap.getExifOrientation());
         }
+      } else if (closeableImage instanceof CloseableDrawable) {
+        CloseableDrawable closeableDrawable = (CloseableDrawable)closeableImage;
+        return closeableDrawable.getUnderlyingDrawable();
       } else if (mAnimatedDrawableFactory != null
           && mAnimatedDrawableFactory.supportsImageType(closeableImage)) {
         return mAnimatedDrawableFactory.createDrawable(closeableImage);

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/SimpleDrawableReleaser.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/SimpleDrawableReleaser.java
@@ -1,0 +1,32 @@
+package com.facebook.imagepipeline.drawable;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import com.facebook.common.references.ResourceReleaser;
+
+/**
+ * A releaser that just recycles (frees) drawable bitmap memory immediately.
+ */
+public class SimpleDrawableReleaser implements ResourceReleaser<Drawable> {
+
+    private static SimpleDrawableReleaser sInstance;
+
+    public static SimpleDrawableReleaser getInstance() {
+        if (sInstance == null) {
+            sInstance = new SimpleDrawableReleaser();
+        }
+        return sInstance;
+    }
+
+    @Override
+    public void release(Drawable value) {
+        if (value instanceof BitmapDrawable) {
+            Bitmap bitmap = ((BitmapDrawable)value).getBitmap();
+            if (bitmap != null) {
+                bitmap.recycle();
+            }
+        }
+    }
+}

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/CloseableDrawable.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/CloseableDrawable.java
@@ -1,0 +1,84 @@
+package com.facebook.imagepipeline.image;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import com.facebook.common.internal.Preconditions;
+import com.facebook.common.references.CloseableReference;
+import com.facebook.common.references.ResourceReleaser;
+import com.facebook.imageutils.BitmapUtil;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * {@link CloseableImage} that wraps a drawable.
+ */
+@ThreadSafe
+public class CloseableDrawable extends CloseableImage {
+
+    @GuardedBy("this")
+    private CloseableReference<Drawable> mDrawableReference;
+
+    private Drawable mDrawable;
+
+    public CloseableDrawable(Drawable drawable, ResourceReleaser<Drawable> resourceReleaser) {
+        mDrawable = drawable;
+        mDrawableReference = CloseableReference.of(
+                mDrawable,
+                Preconditions.checkNotNull(resourceReleaser));
+    }
+
+    /**
+     * Gets the underlying drawable.
+     * Note: some Android drawable resources like xml, vector drawable, adaptive icon can be only decoded
+     * to drawable not bitmap
+     * @return the underlying drawable
+     */
+    public Drawable getUnderlyingDrawable() {
+        return mDrawable;
+    }
+
+    @Override
+    public int getSizeInBytes() {
+
+        if (mDrawable instanceof BitmapDrawable) {
+            Bitmap bitmap = ((BitmapDrawable)mDrawable).getBitmap();
+            return BitmapUtil.getSizeInBytes(bitmap);
+        }
+        // 4 bytes per pixel for ARGB_8888 Bitmaps is something of a reasonable approximation. If
+        // there are no intrinsic bounds, we can fall back just to 1.
+        return Math.max(1, getWidth() * getHeight() * 4);
+    }
+
+    @Override
+    public void close() {
+        CloseableReference<Drawable> reference = detachDrawableReference();
+        if (reference != null) {
+            reference.close();
+        }
+    }
+
+    private synchronized CloseableReference<Drawable> detachDrawableReference() {
+        CloseableReference<Drawable> reference = mDrawableReference;
+        mDrawableReference = null;
+        mDrawable = null;
+        return reference;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return mDrawableReference == null;
+    }
+
+    @Override
+    public int getWidth() {
+        return mDrawable == null ? 0 : Math.max(0, mDrawable.getIntrinsicWidth());
+    }
+
+    @Override
+    public int getHeight() {
+        return mDrawable == null ? 0 : Math.max(0, mDrawable.getIntrinsicHeight());
+    }
+}

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/EncodedImage.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/EncodedImage.java
@@ -9,6 +9,7 @@ package com.facebook.imagepipeline.image;
 
 import android.graphics.ColorSpace;
 import android.media.ExifInterface;
+import android.net.Uri;
 import android.util.Pair;
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.internal.Supplier;
@@ -67,6 +68,7 @@ public class EncodedImage implements Closeable {
   private int mStreamSize = UNKNOWN_STREAM_SIZE;
   private @Nullable BytesRange mBytesRange;
   private @Nullable ColorSpace mColorSpace;
+  private @Nullable Uri mUri;
 
   public EncodedImage(CloseableReference<PooledByteBuffer> pooledByteBufferRef) {
     Preconditions.checkArgument(CloseableReference.isValid(pooledByteBufferRef));
@@ -162,6 +164,13 @@ public class EncodedImage implements Closeable {
   }
 
   /**
+   * Sets the image uri to decode
+   */
+  public void setImageUri(Uri uri) {
+    this.mUri = uri;
+  }
+
+  /**
    * Sets the image format
    */
   public void setImageFormat(ImageFormat imageFormat) {
@@ -210,6 +219,13 @@ public class EncodedImage implements Closeable {
 
   public void setBytesRange(@Nullable BytesRange bytesRange) {
     mBytesRange = bytesRange;
+  }
+
+  /**
+   * Returns the image uri if set
+   */
+  public Uri getImageUri() {
+    return mUri;
   }
 
   /**

--- a/imagepipeline/build.gradle
+++ b/imagepipeline/build.gradle
@@ -7,6 +7,7 @@ version = VERSION_NAME
 dependencies {
     compileOnly "com.android.support:support-annotations:${SUPPORT_LIB_VERSION}"
     compileOnly "com.android.support:support-core-utils:${SUPPORT_LIB_VERSION}"
+    compileOnly "com.android.support:appcompat-v7:${SUPPORT_LIB_VERSION}"
     compileOnly "com.google.code.findbugs:jsr305:${JSR_305_VERSION}"
     compileOnly "com.facebook.infer.annotation:infer-annotation:${INFER_ANNOTATION_VERSION}"
     compileOnly "javax.annotation:javax.annotation-api:${ANNOTATION_API_VERSION}"

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -36,6 +36,7 @@ import com.facebook.imagepipeline.cache.EncodedMemoryCacheFactory;
 import com.facebook.imagepipeline.cache.InstrumentedMemoryCache;
 import com.facebook.imagepipeline.decoder.DefaultImageDecoder;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
+import com.facebook.imagepipeline.decoder.ResourceDrawableDecoder;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.memory.PoolFactory;
@@ -210,15 +211,19 @@ public class ImagePipelineFactory {
           webPDecoder = animatedFactory.getWebPDecoder(mConfig.getBitmapConfig());
         }
 
+        ImageDecoder resourceDecoder = new ResourceDrawableDecoder(mConfig.getContext());
+
         if (mConfig.getImageDecoderConfig() == null) {
           mImageDecoder = new DefaultImageDecoder(
               gifDecoder,
               webPDecoder,
+              resourceDecoder,
               getPlatformDecoder());
         } else {
           mImageDecoder = new DefaultImageDecoder(
               gifDecoder,
               webPDecoder,
+              resourceDecoder,
               getPlatformDecoder(),
               mConfig.getImageDecoderConfig().getCustomImageDecoders());
           // Add custom image formats if needed

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DrawableDecoderCompat.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DrawableDecoderCompat.java
@@ -1,0 +1,77 @@
+package com.facebook.imagepipeline.decoder;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.res.ResourcesCompat;
+import android.support.v7.content.res.AppCompatResources;
+import android.support.v7.view.ContextThemeWrapper;
+
+/**
+ * Handles decoding Drawables with the v7 support library if present and falling back to the v4
+ * support library otherwise.
+ */
+public final class DrawableDecoderCompat {
+    private static volatile boolean shouldCallAppCompatResources = true;
+    private DrawableDecoderCompat() {
+        // Utility class.
+    }
+
+    /**
+     * See {@code getDrawable(Context, int, Theme)}.
+     */
+    public static Drawable getDrawable(
+            Context ourContext, Context targetContext, @DrawableRes int id) {
+        return getDrawable(ourContext, targetContext, id, /*theme=*/ null);
+    }
+
+    /**
+     * Loads a Drawable using {@link AppCompatResources} if available and {@link ResourcesCompat}
+     * otherwise, depending on whether or not the v7 support library is included in the application.
+     *
+     * @param theme Used instead of the {@link Resources.Theme} returned from the given {@link Context} if
+     * non-null when loading the {@link Drawable}.
+     */
+    public static Drawable getDrawable(
+            Context ourContext, @DrawableRes int id, @Nullable Resources.Theme theme) {
+        return getDrawable(ourContext, ourContext, id, theme);
+    }
+
+    private static Drawable getDrawable(
+            Context ourContext, Context targetContext, @DrawableRes int id, @Nullable Resources.Theme theme) {
+        try {
+            // Race conditions may cause us to attempt to load using v7 more than once. That's ok since
+            // this check is a modest optimization and the output will be correct anyway.
+            if (shouldCallAppCompatResources) {
+                return loadDrawableV7(targetContext, id, theme);
+            }
+        } catch (NoClassDefFoundError error) {
+            shouldCallAppCompatResources = false;
+        } catch (IllegalStateException e) {
+            if (ourContext.getPackageName().equals(targetContext.getPackageName())) {
+                throw e;
+            }
+            return ContextCompat.getDrawable(targetContext, id);
+        } catch (Resources.NotFoundException e) {
+            // Ignored, this can be thrown when drawable compat attempts to decode a canary resource. If
+            // that decode attempt fails, we still want to try with the v4 ResourcesCompat below.
+        }
+
+        return loadDrawableV4(targetContext, id, theme != null ? theme : targetContext.getTheme());
+    }
+
+    private static Drawable loadDrawableV7(Context context, @DrawableRes int id,
+                                           @Nullable Resources.Theme theme) {
+        Context resourceContext = theme != null ? new ContextThemeWrapper(context, theme) : context;
+        return AppCompatResources.getDrawable(resourceContext, id);
+    }
+
+    private static Drawable loadDrawableV4(
+            Context context, @DrawableRes int id, @Nullable Resources.Theme theme) {
+        Resources resources = context.getResources();
+        return ResourcesCompat.getDrawable(resources, id, theme);
+    }
+}

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/ResourceDrawableDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/ResourceDrawableDecoder.java
@@ -1,0 +1,59 @@
+package com.facebook.imagepipeline.decoder;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import com.facebook.common.util.UriUtil;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
+import com.facebook.imagepipeline.drawable.SimpleDrawableReleaser;
+import com.facebook.imagepipeline.image.CloseableDrawable;
+import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.EncodedImage;
+import com.facebook.imagepipeline.image.QualityInfo;
+
+
+
+/**
+ * Decodes images to {@link Drawable}
+ *
+ */
+public class ResourceDrawableDecoder implements ImageDecoder {
+
+    private final Context context;
+
+    public ResourceDrawableDecoder(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Override
+    public CloseableImage decode(EncodedImage encodedImage, int length, QualityInfo qualityInfo, ImageDecodeOptions options) {
+        Uri uri = encodedImage.getImageUri();
+        if (uri == null) {
+            throw new IllegalArgumentException("Uri is null");
+        }
+
+        @DrawableRes int resId = UriUtil.getResourceIdFromUri(context, uri);
+        String pkgName = uri.getAuthority();
+        Context targetContext = (TextUtils.isEmpty(pkgName) || TextUtils.equals(pkgName, context.getPackageName()))
+                ? context : getContextForPackage(uri, pkgName);
+        // We can't get a theme from another application.
+        Drawable drawable = DrawableDecoderCompat.getDrawable(context, targetContext, resId);
+        return new CloseableDrawable(drawable, SimpleDrawableReleaser.getInstance());
+    }
+
+
+    @NonNull
+    private Context getContextForPackage(Uri source, String packageName) {
+        try {
+            return context.createPackageContext(packageName, /*flags=*/ 0);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new IllegalArgumentException(
+                    "Failed to obtain context or unrecognized Uri format for: " + source, e);
+        }
+    }
+}

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
@@ -146,8 +146,9 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
             @Override
             public void run(EncodedImage encodedImage, @Status int status) {
               if (encodedImage != null) {
+                ImageRequest request = producerContext.getImageRequest();
+                encodedImage.setImageUri(request.getSourceUri());
                 if (mDownsampleEnabled || !statusHasFlag(status, Consumer.IS_RESIZING_DONE)) {
-                  ImageRequest request = producerContext.getImageRequest();
                   if (mDownsampleEnabledForNetwork
                       || !UriUtil.isNetworkUri(request.getSourceUri())) {
                     encodedImage.setSampleSize(


### PR DESCRIPTION
## Motivation 

Fresco can only decode resources to Bitmap and not support Drawable. In android platform, drawable is a higher abstraction that can be draw. Sometimes, we want to set a resId in res/drawable to the SimpleDraweeView such as shape drawable or vector drawable, but those cases are not supported by Fresco. Meanwhile, Glide can correctly handle local resources under res/drawable. When Glide found the res can not be decoded into Bitmap, it will try to decode the res to Drawable as a fallback. See https://github.com/bumptech/glide/blob/master/library/src/main/java/com/bumptech/glide/load/resource/drawable/ResourceDrawableDecoder.java#L24  

Though fresco support writing custom decoders to implement the same effect, but it is hard to judge a resId should be decoded to Bitmap or Drawable, because xml file has no major number in header and has been compiled to binary format in apk that can only be recognized by framework. At the same time, when writing a custom decoder to support our own drawable, we have to write at least four classes: a FormatChecker, a CloseableImage, a ImageDecoder, a DrawableFactory.

Some requirement are found in issue #1463 #2173

To solve the existing issue, I have add some code in Fresco to support decode resource to Drawable directly. Changes as following

* Add a `CloseableDrawable` that can wrap the decoded Drawable, this can be returned by our custom decoder. When we write custom decoder, we have no need to implement `CloseableImage` and `DrawableFactory` anymore for basic usage.
* Add a `ResourceDrawableDecoder` to decode a resId to Drawable. The resId can from this app or outer app such as icon.
* Enhance the function of `DefaultImageDecoder` to decode resId to Drawable. When trying to decode an EncodedImage, if we cannot get its image format but we know it is a local resource uri, then we entry a fallback mode and try use `ResourceDrawableDecoder` to decode resId to a Drawable bypass Bitmap. Drawable can also be set into `SimpleDraweeView`.
* Add appcompat-v7 dependency but it is optional by a trick implement. We try to use `AppCompatResources` in support-v7 to getDrawable from resId first because it supports vector drawable for pre-Lollilop devices. If the app do not import support-v7, it will fail once and then use `ContextCompat` in support-v4 to getDrawable. Though Fresco do not want to import support-v7, but there is not very elegant way to work for it.

## Test Plan 

case 1: create a shape drawable xml and load it into SimpleDraweeView.

```
draweeView.setImageUri("res:///"+R.id.shape_dr);
```

case 2: create a vector drawable xml and load it into SimpleDraweeView.

case 3: load an icon from other app into SimpleDraweeView, the icon might be adaptive icon.

```
String pkgName = "com.android.chrome";
PackageManager pm = context.getPackageManager();
ApplicationInfo info = pm.getApplicationInfo(pkgName, 0);
if (info != null && info.icon > 0){
    Uri uri = Uri.parse("android.resources://" + pkgName +"/" + info.icon);
    draweeView.setImageUri(uri);
}
```

case 4: rewrite `SvgDecoder` in `SvgDecoderExample` to return a `ClosableDrawable` and simplify code and it still works well.

```
public static class SvgDecoder implements ImageDecoder {

    @Override
    public CloseableImage decode(
        EncodedImage encodedImage,
        int length,
        QualityInfo qualityInfo,
        ImageDecodeOptions options) {
      try {
        SVG svg = SVG.getFromInputStream(encodedImage.getInputStream());
        return new CloseableDrawable(new SvgPictureDrawable(svg);
      } catch (SVGParseException e) {
        e.printStackTrace();
      }
      return null;
    }
  }
```

Please review the changes and give some suggestions to optimize the issue. I am not concern whether the changes follow the Fresco design or not.