### PR TITLE
Add option that caches video thumbnails to disk

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineExperiments.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineExperiments.java
@@ -21,6 +21,7 @@ import com.facebook.imagepipeline.cache.MemoryCache;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
 import com.facebook.imagepipeline.decoder.ProgressiveJpegConfig;
 import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.memory.BitmapPool;
 import com.facebook.imageutils.BitmapUtil;
 
 /**
@@ -251,6 +252,7 @@ public class ImagePipelineExperiments {
 
     ProducerFactory createProducerFactory(
         Context context,
+        BitmapPool bitmapPool,
         ByteArrayPool byteArrayPool,
         ImageDecoder imageDecoder,
         ProgressiveJpegConfig progressiveJpegConfig,
@@ -276,6 +278,7 @@ public class ImagePipelineExperiments {
     @Override
     public ProducerFactory createProducerFactory(
         Context context,
+        BitmapPool bitmapPool,
         ByteArrayPool byteArrayPool,
         ImageDecoder imageDecoder,
         ProgressiveJpegConfig progressiveJpegConfig,
@@ -296,6 +299,7 @@ public class ImagePipelineExperiments {
         int maxBitmapSize) {
       return new ProducerFactory(
           context,
+          bitmapPool,
           byteArrayPool,
           imageDecoder,
           progressiveJpegConfig,

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -349,6 +349,7 @@ public class ImagePipelineFactory {
               .getProducerFactoryMethod()
               .createProducerFactory(
                   mConfig.getContext(),
+                  mConfig.getPoolFactory().getBitmapPool(),
                   mConfig.getPoolFactory().getSmallByteArrayPool(),
                   getImageDecoder(),
                   mConfig.getProgressiveJpegConfig(),

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ProducerFactory.java
@@ -24,6 +24,7 @@ import com.facebook.imagepipeline.decoder.ImageDecoder;
 import com.facebook.imagepipeline.decoder.ProgressiveJpegConfig;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.EncodedImage;
+import com.facebook.imagepipeline.memory.BitmapPool;
 import com.facebook.imagepipeline.producers.AddImageTransformMetaDataProducer;
 import com.facebook.imagepipeline.producers.BitmapMemoryCacheGetProducer;
 import com.facebook.imagepipeline.producers.BitmapMemoryCacheKeyMultiplexProducer;
@@ -43,6 +44,7 @@ import com.facebook.imagepipeline.producers.LocalExifThumbnailProducer;
 import com.facebook.imagepipeline.producers.LocalFileFetchProducer;
 import com.facebook.imagepipeline.producers.LocalResourceFetchProducer;
 import com.facebook.imagepipeline.producers.LocalVideoThumbnailProducer;
+import com.facebook.imagepipeline.producers.LocalVideoThumbnailProducer2;
 import com.facebook.imagepipeline.producers.NetworkFetchProducer;
 import com.facebook.imagepipeline.producers.NetworkFetcher;
 import com.facebook.imagepipeline.producers.NullProducer;
@@ -71,6 +73,7 @@ public class ProducerFactory {
   private AssetManager mAssetManager;
 
   // Decode dependencies
+  private final BitmapPool mBitmapPool;
   private final ByteArrayPool mByteArrayPool;
   private final ImageDecoder mImageDecoder;
   private final ProgressiveJpegConfig mProgressiveJpegConfig;
@@ -101,6 +104,7 @@ public class ProducerFactory {
 
   public ProducerFactory(
       Context context,
+      BitmapPool bitmapPool,
       ByteArrayPool byteArrayPool,
       ImageDecoder imageDecoder,
       ProgressiveJpegConfig progressiveJpegConfig,
@@ -123,6 +127,7 @@ public class ProducerFactory {
     mResources = context.getApplicationContext().getResources();
     mAssetManager = context.getApplicationContext().getAssets();
 
+    mBitmapPool = bitmapPool;
     mByteArrayPool = byteArrayPool;
     mImageDecoder = imageDecoder;
     mProgressiveJpegConfig = progressiveJpegConfig;
@@ -290,6 +295,14 @@ public class ProducerFactory {
 
   public LocalVideoThumbnailProducer newLocalVideoThumbnailProducer() {
     return new LocalVideoThumbnailProducer(
+        mExecutorSupplier.forLocalStorageRead(),
+        mContentResolver);
+  }
+
+  public LocalVideoThumbnailProducer2 newLocalVideoThumbnailProducer2() {
+    return new LocalVideoThumbnailProducer2(
+        mPooledByteBufferFactory,
+        mBitmapPool,
         mExecutorSupplier.forLocalStorageRead(),
         mContentResolver);
   }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer2.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer2.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.imagepipeline.producers;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.media.ThumbnailUtils;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.DocumentsContract;
+import android.provider.MediaStore;
+import android.support.annotation.Nullable;
+import com.facebook.common.internal.ImmutableMap;
+import com.facebook.common.internal.VisibleForTesting;
+import com.facebook.common.memory.PooledByteBuffer;
+import com.facebook.common.memory.PooledByteBufferFactory;
+import com.facebook.common.memory.PooledByteBufferOutputStream;
+import com.facebook.common.references.CloseableReference;
+import com.facebook.common.util.UriUtil;
+import com.facebook.imagepipeline.image.EncodedImage;
+import com.facebook.imagepipeline.memory.BitmapPool;
+import com.facebook.imagepipeline.request.ImageRequest;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * A producer that creates video thumbnails.
+ *
+ * <p> Those thumbnails will be transformed into EncodedImage and put into disk cache if need
+ *
+ */
+public class LocalVideoThumbnailProducer2 implements
+    Producer<EncodedImage> {
+
+  public static final String PRODUCER_NAME = "VideoThumbnailProducer";
+  @VisibleForTesting static final String CREATED_THUMBNAIL = "createdThumbnail";
+
+  private final Executor mExecutor;
+  private final ContentResolver mContentResolver;
+  private final PooledByteBufferFactory mPooledByteBufferFactory;
+  private final BitmapPool mBitmapPool;
+
+  public LocalVideoThumbnailProducer2(
+      PooledByteBufferFactory pooledByteBufferFactory,
+      BitmapPool bitmapPool,
+      Executor executor,
+      ContentResolver contentResolver) {
+    mPooledByteBufferFactory = pooledByteBufferFactory;
+    mBitmapPool = bitmapPool;
+    mExecutor = executor;
+    mContentResolver = contentResolver;
+  }
+
+  @Override
+  public void produceResults(
+      final Consumer<EncodedImage> consumer,
+      final ProducerContext producerContext) {
+
+    final ProducerListener listener = producerContext.getListener();
+    final String requestId = producerContext.getId();
+    final ImageRequest imageRequest = producerContext.getImageRequest();
+    final StatefulProducerRunnable cancellableProducerRunnable =
+        new StatefulProducerRunnable<EncodedImage>(
+            consumer,
+            listener,
+            PRODUCER_NAME,
+            requestId) {
+          @Override
+          protected void onSuccess(EncodedImage result) {
+            super.onSuccess(result);
+            listener.onUltimateProducerReached(requestId, PRODUCER_NAME, result != null);
+          }
+
+          @Override
+          protected void onFailure(Exception e) {
+            super.onFailure(e);
+            listener.onUltimateProducerReached(requestId, PRODUCER_NAME, false);
+          }
+
+          @Override
+          protected EncodedImage getResult() throws Exception {
+            EncodedImage encodedImage = getEncodedImage(imageRequest);
+            if (encodedImage == null) {
+              listener.onUltimateProducerReached(requestId, PRODUCER_NAME, false);
+              return null;
+            }
+            encodedImage.parseMetaData();
+            listener.onUltimateProducerReached(requestId, PRODUCER_NAME, true);
+            return encodedImage;
+          }
+
+          @Override
+          protected Map<String, String> getExtraMapOnSuccess(
+              final EncodedImage result) {
+            return ImmutableMap.of(CREATED_THUMBNAIL, String.valueOf(result != null));
+          }
+
+          @Override
+          protected void disposeResult(EncodedImage result) {
+            EncodedImage.closeSafely(result);
+          }
+        };
+    producerContext.addCallbacks(
+        new BaseProducerContextCallbacks() {
+          @Override
+          public void onCancellationRequested() {
+            cancellableProducerRunnable.cancel();
+          }
+        });
+    mExecutor.execute(cancellableProducerRunnable);
+  }
+
+
+  protected EncodedImage getEncodedImage(ImageRequest imageRequest) {
+    String path = getLocalFilePath(imageRequest);
+    if (path == null) {
+      return null;
+    }
+    Bitmap thumbnailBitmap = ThumbnailUtils.createVideoThumbnail(
+        path,
+        calculateKind(imageRequest));
+    if (thumbnailBitmap == null) {
+      return null;
+    }
+
+    PooledByteBufferOutputStream pooledOutputStream = mPooledByteBufferFactory.newOutputStream();
+    try {
+      thumbnailBitmap.compress(thumbnailBitmap.hasAlpha() ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG,
+          100, pooledOutputStream);
+      return getByteBufferBackedEncodedImage(pooledOutputStream);
+    } finally {
+      mBitmapPool.release(thumbnailBitmap);
+      pooledOutputStream.close();
+    }
+  }
+
+  private EncodedImage getByteBufferBackedEncodedImage(
+      PooledByteBufferOutputStream pooledOutputStream) {
+    CloseableReference<PooledByteBuffer> result = null;
+    try {
+      result = CloseableReference.of(pooledOutputStream.toByteBuffer());
+      return new EncodedImage(result);
+    } finally {
+      CloseableReference.closeSafely(result);
+    }
+  }
+
+  private static int calculateKind(ImageRequest imageRequest) {
+    if (imageRequest.getPreferredWidth() > 96 || imageRequest.getPreferredHeight() > 96) {
+      return MediaStore.Images.Thumbnails.MINI_KIND;
+    }
+    return MediaStore.Images.Thumbnails.MICRO_KIND;
+  }
+
+  @Nullable private String getLocalFilePath(ImageRequest imageRequest) {
+    Uri uri = imageRequest.getSourceUri();
+    if (UriUtil.isLocalFileUri(uri)) {
+      return imageRequest.getSourceFile().getPath();
+    } else if (UriUtil.isLocalContentUri(uri)) {
+      String selection = null;
+      String[] selectionArgs = null;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT
+          && "com.android.providers.media.documents".equals(uri.getAuthority())) {
+        String documentId = DocumentsContract.getDocumentId(uri);
+        uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+        selection = MediaStore.Video.Media._ID + "=?";
+        selectionArgs = new String[] {documentId.split(":")[1]};
+      }
+      Cursor cursor =
+          mContentResolver.query(
+              uri, new String[] {MediaStore.Video.Media.DATA}, selection, selectionArgs, null);
+      try {
+        if (cursor != null && cursor.moveToFirst()) {
+          return cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DATA));
+        }
+      } finally {
+        if (cursor != null) {
+          cursor.close();
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequest.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequest.java
@@ -74,11 +74,17 @@ public class ImageRequest {
   /** Lowest level that is permitted to fetch an image from */
   private final RequestLevel mLowestPermittedRequestLevel;
 
-  /** Whether the disk cache should be used for this request */
+  /** Whether the disk cache should be used for this request, which is partly dependent on the URI. */
   private final boolean mIsDiskCacheEnabled;
 
   /** Whether the memory cache should be used for this request */
   private final boolean mIsMemoryCacheEnabled;
+
+  /** Whether the decoded video thumbnail should be store to local disk image cache */
+  private final boolean mIsVideoThumbnailDiskCacheEnabled;
+
+  /** Whether the source uri is local video */
+  private boolean mIsLocalVideoUri = false;
 
   /** Postprocessor to run on the output bitmap. */
   private final @Nullable Postprocessor mPostprocessor;
@@ -117,6 +123,7 @@ public class ImageRequest {
     mLowestPermittedRequestLevel = builder.getLowestPermittedRequestLevel();
     mIsDiskCacheEnabled = builder.isDiskCacheEnabled();
     mIsMemoryCacheEnabled = builder.isMemoryCacheEnabled();
+    mIsVideoThumbnailDiskCacheEnabled = builder.isVideoThumbnailDiskCacheEnabled();
 
     mPostprocessor = builder.getPostprocessor();
 
@@ -185,7 +192,16 @@ public class ImageRequest {
   }
 
   public boolean isDiskCacheEnabled() {
-    return mIsDiskCacheEnabled;
+    return mIsDiskCacheEnabled && (UriUtil.isNetworkUri(mSourceUri)
+      || (mIsVideoThumbnailDiskCacheEnabled && mIsLocalVideoUri));
+  }
+
+  public boolean isVideoThumbnailDiskCacheEnabled() {
+    return mIsDiskCacheEnabled && (mIsVideoThumbnailDiskCacheEnabled && mIsLocalVideoUri);
+  }
+
+  public void setIsLocalVideoUri(boolean localVideoUri) {
+    mIsLocalVideoUri = localVideoUri;
   }
 
   public boolean isMemoryCacheEnabled() {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequestBuilder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/request/ImageRequestBuilder.java
@@ -41,6 +41,7 @@ public class ImageRequestBuilder {
   private @Nullable Postprocessor mPostprocessor = null;
   private boolean mDiskCacheEnabled = true;
   private boolean mMemoryCacheEnabled = true;
+  private boolean mVideoThumbnailDiskCacheEnable = true;
   private @Nullable RequestListener mRequestListener;
   private @Nullable BytesRange mBytesRange = null;
 
@@ -263,9 +264,20 @@ public class ImageRequestBuilder {
     return this;
   }
 
-  /** Returns whether the use of the disk cache is enabled, which is partly dependent on the URI. */
+  /** Returns whether the use of the disk cache is enabled */
   public boolean isDiskCacheEnabled() {
-    return mDiskCacheEnabled && UriUtil.isNetworkUri(mSourceUri);
+    return mDiskCacheEnabled;
+  }
+
+  /** Disables video thumbnail disk cache for this request if the image come from local video. */
+  public ImageRequestBuilder disableVideoThumbnailDiskCache() {
+    mVideoThumbnailDiskCacheEnable = false;
+    return this;
+  }
+
+  /** Return whether the disk cache of local video thumbnails is enabled */
+  public boolean isVideoThumbnailDiskCacheEnabled() {
+    return mVideoThumbnailDiskCacheEnable;
   }
 
   /** Disables memory cache for this request. */


### PR DESCRIPTION
## Motivation 

As #2171 comments, Fresco loads a thumbnail from local video URI without disk cache. Every time restart app or bitmap in memory cache are evicted, then Fresco need decode thumbnail from video again and it will be slow and poor performance. So put the thumbnail bitmap into disk cache will be a good choice.

To optimize for this case, I create a `LocalVideoThumbnailProducer2` class that will return an `EncodedImage`, and then it can be consumed by `DiskCacheWriteProducer` and `EncodedMemoryCacheProducer`. We can build a new producer sequence for this case, see `ProducerSequenceFactory#getLocalVideoFileFetchSequence2()`.

Of course, it is a feature that you can enable/disable it by `ImageRequestBuilder`, but I think it should be enabled by default.

## Test Plan 

put a video file test.mp4 in sdcard and got the READ_EXTERNAL_STORAGE permission, and use following code to test.

```
File file =  new File(Environment.getExternalStorageDirectory(), "test.mp4");
draweeView.setImageURI(Uri.fromFile(file));
```
