### PR TITLE
Supplement heif header suffixes

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormatChecker.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imageformat/DefaultImageFormatChecker.java
@@ -245,7 +245,7 @@ public class DefaultImageFormatChecker implements ImageFormat.FormatChecker {
    */
   private static final String HEIF_HEADER_PREFIX = "ftyp";
 
-  private static final String[] HEIF_HEADER_SUFFIXES = {"heic", "heix", "hevc", "hevx"};
+  private static final String[] HEIF_HEADER_SUFFIXES = {"heic", "heix", "hevc", "hevx", "mif1", "msf1"};
   private static final int HEIF_HEADER_LENGTH =
       ImageFormatCheckerUtils.asciiBytes(HEIF_HEADER_PREFIX + HEIF_HEADER_SUFFIXES[0]).length;
 


### PR DESCRIPTION
## Motivation (required)

Some heif header suffixes missed, cause some heif image can not load successfully, such as https://nokiatech.github.io/heif/content/images/autumn_1440x960.heic.

## Test Plan (required)

Load the image https://nokiatech.github.io/heif/content/images/autumn_1440x960.heic, then check whether load successfully.

