### PR TITLE
fix bug when using DownSample and RegionDecoder together

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/DefaultDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/DefaultDecoder.java
@@ -183,8 +183,8 @@ public abstract class DefaultDecoder implements PlatformDecoder {
     int targetWidth = options.outWidth;
     int targetHeight = options.outHeight;
     if (regionToDecode != null) {
-      targetWidth = regionToDecode.width();
-      targetHeight = regionToDecode.height();
+      targetWidth = regionToDecode.width()/options.inSampleSize;
+      targetHeight = regionToDecode.height()/options.inSampleSize;
     }
     int sizeInBytes = getBitmapSize(targetWidth, targetHeight, options);
     final Bitmap bitmapToReuse = mBitmapPool.get(sizeInBytes);


### PR DESCRIPTION
## Motivation

To fix the bug discribed in issue [2201](https://github.com/facebook/fresco/issues/2201)

## Test Plan

The Image can not show correctly when using Resize and RegionDecoder together with `downsample` setting to `true`. Here I change the `targetWidth` and `targetHeight` with region decoder to fix the bug.
when not `setDownsampleEnable` is not  set to `true` or using default value. Resize is a process of pipeline before decoding (only for JPEG). so the region is not the same with the former. but this can be set in custom decoder.