### PR TITLE
Remove trailing slash from site URL

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,6 @@
 ---
 permalink: /blog/:categories/:year/:month/:day/:title.html
-url: "https://facebook.github.io/fresco/"
-cdn_url: "https://frescolib.org/"
+url: "https://frescolib.org"
 title: Fresco
 tagline: An Image Management Library
 fbappid: "1615782811974223"

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -5,8 +5,8 @@
 
   {% seo %}
 
-  <link rel="stylesheet" href="{{ site.cdn_url }}{{ site.baseurl }}/css/main.css" media="screen">
-  <link rel="icon" href="{{ site.cdn_url }}{{ site.baseurl }}/static/favicon.png" type="image/x-icon">
+  <link rel="stylesheet" href="{{ site.url }}{{ site.baseurl }}/css/main.css" media="screen">
+  <link rel="icon" href="{{ site.url }}{{ site.baseurl }}/static/favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
 
   <script src="https://unpkg.com/react@0.13.1/dist/react-with-addons.min.js"></script>


### PR DESCRIPTION
## Motivation (required)

Since #2218 links to CSS and secondary pages were broken due to the trailing slash. This removes it and also removes the cdn_url config as having the primary url pointing to facebook.github.io meant the frescolib.org domain disappeared for subsequent pages.

## Test Plan (required)

Running jekyll locally.