### PR TITLE
Add explicit color management.

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptions.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptions.java
@@ -8,6 +8,7 @@
 package com.facebook.imagepipeline.common;
 
 import android.graphics.Bitmap;
+import android.graphics.ColorSpace;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
 import com.facebook.imagepipeline.transformation.BitmapTransformation;
 import java.util.Locale;
@@ -52,12 +53,6 @@ public class ImageDecodeOptions {
   public final boolean forceStaticImage;
 
   /**
-   * Allow color space transformation to sRGB. This flag can affect performance, unless the color
-   * space is unknown or if the color space is already sRGB.
-   */
-  public final boolean transformToSRGB;
-
-  /**
    * StaticImage and JPEG will decode with this config;
    */
   public final Bitmap.Config bitmapConfig;
@@ -70,6 +65,13 @@ public class ImageDecodeOptions {
   /** Bitmap transformation override */
   public final @Nullable BitmapTransformation bitmapTransformation;
 
+  /**
+   * Allow explicit color management, must be one of the named color space in ColorSpace.Named.
+   * This flag might affect performance, if null, then SRGB color space is assumed if the
+   * SDK version >= 26.
+   */
+  public final @Nullable ColorSpace colorSpace;
+
   public ImageDecodeOptions(ImageDecodeOptionsBuilder b) {
     this.minDecodeIntervalMs = b.getMinDecodeIntervalMs();
     this.decodePreviewFrame = b.getDecodePreviewFrame();
@@ -78,8 +80,8 @@ public class ImageDecodeOptions {
     this.forceStaticImage = b.getForceStaticImage();
     this.bitmapConfig = b.getBitmapConfig();
     this.customImageDecoder = b.getCustomImageDecoder();
-    this.transformToSRGB = b.getTransformToSRGB();
     this.bitmapTransformation = b.getBitmapTransformation();
+    this.colorSpace = b.getColorSpace();
   }
 
   /**
@@ -111,10 +113,10 @@ public class ImageDecodeOptions {
     if (useLastFrameForPreview != that.useLastFrameForPreview) return false;
     if (decodeAllFrames != that.decodeAllFrames) return false;
     if (forceStaticImage != that.forceStaticImage) return false;
-    if (transformToSRGB != that.transformToSRGB) return false;
     if (bitmapConfig != that.bitmapConfig) return false;
     if (customImageDecoder != that.customImageDecoder) return false;
     if (bitmapTransformation != that.bitmapTransformation) return false;
+    if (colorSpace != that.colorSpace) return false;
     return true;
   }
 
@@ -125,10 +127,10 @@ public class ImageDecodeOptions {
     result = 31 * result + (useLastFrameForPreview ? 1 : 0);
     result = 31 * result + (decodeAllFrames ? 1 : 0);
     result = 31 * result + (forceStaticImage ? 1 : 0);
-    result = 31 * result + (transformToSRGB ? 1 : 0);
     result = 31 * result + bitmapConfig.ordinal();
     result = 31 * result + (customImageDecoder != null ? customImageDecoder.hashCode() : 0);
     result = 31 * result + (bitmapTransformation != null ? bitmapTransformation.hashCode() : 0);
+    result = 31 * result + (colorSpace != null ? colorSpace.hashCode() : 0);
     return result;
   }
 
@@ -142,9 +144,9 @@ public class ImageDecodeOptions {
         useLastFrameForPreview,
         decodeAllFrames,
         forceStaticImage,
-        transformToSRGB,
         bitmapConfig.name(),
         customImageDecoder,
-        bitmapTransformation);
+        bitmapTransformation,
+        colorSpace);
   }
 }

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptionsBuilder.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/common/ImageDecodeOptionsBuilder.java
@@ -8,9 +8,11 @@
 package com.facebook.imagepipeline.common;
 
 import android.graphics.Bitmap;
+import android.graphics.ColorSpace;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
 import com.facebook.imagepipeline.transformation.BitmapTransformation;
 import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /**
  * Builder for {@link ImageDecodeOptions}.
@@ -26,6 +28,7 @@ public class ImageDecodeOptionsBuilder {
   private Bitmap.Config mBitmapConfig = Bitmap.Config.ARGB_8888;
   private @Nullable ImageDecoder mCustomImageDecoder;
   private @Nullable BitmapTransformation mBitmapTransformation;
+  private @Nullable ColorSpace mColorSpace;
 
   public ImageDecodeOptionsBuilder() {
   }
@@ -43,8 +46,8 @@ public class ImageDecodeOptionsBuilder {
     mForceStaticImage = options.forceStaticImage;
     mBitmapConfig = options.bitmapConfig;
     mCustomImageDecoder = options.customImageDecoder;
-    mTransformToSRGB = options.transformToSRGB;
     mBitmapTransformation = options.bitmapTransformation;
+    mColorSpace = options.colorSpace;
     return this;
   }
 
@@ -198,26 +201,6 @@ public class ImageDecodeOptionsBuilder {
   }
 
   /**
-   * Gets whether to allow or not an image color space to be transformed into sRGB.
-   *
-   * @return whether to allow the color space to be transformed into sRGB.
-   */
-  public boolean getTransformToSRGB() {
-    return mTransformToSRGB;
-  }
-
-  /**
-   * Sets whether to allow or not the color space transformation of the image.
-   *
-   * @param transformToSRGB whether to allow the color space to be transformed to sRGB
-   * @return this builder
-   */
-  public ImageDecodeOptionsBuilder setTransformToSRGB(boolean transformToSRGB) {
-    mTransformToSRGB = transformToSRGB;
-    return this;
-  }
-
-  /**
    * Set a custom in-place bitmap transformation that is applied immediately after decoding.
    *
    * @param bitmapTransformation the transformation to use
@@ -233,6 +216,25 @@ public class ImageDecodeOptionsBuilder {
   public BitmapTransformation getBitmapTransformation() {
     return mBitmapTransformation;
   }
+
+  /**
+   * Sets the target color space for decoding. When possible, the color space transformation will
+   * be performed at load time. This requires SDK version >= 26, otherwise it's a no-op.
+   *
+   * @param colorSpace target color space for decoding.
+   */
+  public ImageDecodeOptionsBuilder setColorSpace(@Nonnull ColorSpace colorSpace) {
+    mColorSpace = colorSpace;
+    return this;
+  }
+
+  /**
+   * Gets the target color space for decoding.
+   *
+   * @return the target color space.
+   */
+  @Nullable
+  public ColorSpace getColorSpace() { return mColorSpace; }
 
   /**
    * Builds the immutable {@link ImageDecodeOptions} instance.

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DefaultImageDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DefaultImageDecoder.java
@@ -147,7 +147,7 @@ public class DefaultImageDecoder implements ImageDecoder {
       ImageDecodeOptions options) {
     CloseableReference<Bitmap> bitmapReference =
         mPlatformDecoder.decodeFromEncodedImageWithColorSpace(
-            encodedImage, options.bitmapConfig, null, options.transformToSRGB);
+            encodedImage, options.bitmapConfig, null, options.colorSpace);
     try {
       maybeApplyTransformation(options.bitmapTransformation, bitmapReference);
       return new CloseableStaticBitmap(
@@ -175,7 +175,7 @@ public class DefaultImageDecoder implements ImageDecoder {
       ImageDecodeOptions options) {
     CloseableReference<Bitmap> bitmapReference =
         mPlatformDecoder.decodeJPEGFromEncodedImageWithColorSpace(
-            encodedImage, options.bitmapConfig, null, length, options.transformToSRGB);
+            encodedImage, options.bitmapConfig, null, length, options.colorSpace);
     try {
       maybeApplyTransformation(options.bitmapTransformation, bitmapReference);
       return new CloseableStaticBitmap(

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
@@ -9,6 +9,7 @@ package com.facebook.imagepipeline.nativecode;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.ColorSpace;
 import android.graphics.Rect;
 import android.os.Build;
 import com.facebook.common.internal.DoNotStrip;
@@ -51,7 +52,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
   @Override
   public CloseableReference<Bitmap> decodeFromEncodedImage(
       EncodedImage encodedImage, Bitmap.Config bitmapConfig, @Nullable Rect regionToDecode) {
-    return decodeFromEncodedImageWithColorSpace(encodedImage, bitmapConfig, regionToDecode, false);
+    return decodeFromEncodedImageWithColorSpace(encodedImage, bitmapConfig, regionToDecode, null);
   }
 
   @Override
@@ -61,7 +62,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
       @Nullable Rect regionToDecode,
       int length) {
     return decodeJPEGFromEncodedImageWithColorSpace(
-        encodedImage, bitmapConfig, regionToDecode, length, false);
+        encodedImage, bitmapConfig, regionToDecode, length, null);
   }
 
   /**
@@ -71,7 +72,9 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
    * @param bitmapConfig the {@link android.graphics.Bitmap.Config} used to create the decoded
    *     Bitmap
    * @param regionToDecode optional image region to decode. currently not supported.
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @throws TooManyBitmapsException if the pool is full
    * @throws java.lang.OutOfMemoryError if the Bitmap cannot be allocated
@@ -81,10 +84,14 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
       final EncodedImage encodedImage,
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
-      final boolean transformToSRGB) {
+      @Nullable final ColorSpace colorSpace) {
     BitmapFactory.Options options = getBitmapFactoryOptions(
         encodedImage.getSampleSize(),
         bitmapConfig);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      options.inPreferredColorSpace = colorSpace == null
+              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
+    }
     CloseableReference<PooledByteBuffer> bytesRef = encodedImage.getByteBufferRef();
     Preconditions.checkNotNull(bytesRef);
     try {
@@ -103,7 +110,9 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
    *     Bitmap
    * @param regionToDecode optional image region to decode. currently not supported.
    * @param length the number of encoded bytes in the buffer
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @throws TooManyBitmapsException if the pool is full
    * @throws java.lang.OutOfMemoryError if the Bitmap cannot be allocated
@@ -114,10 +123,14 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
       int length,
-      final boolean transformToSRGB) {
+      @Nullable final ColorSpace colorSpace) {
     BitmapFactory.Options options = getBitmapFactoryOptions(
         encodedImage.getSampleSize(),
         bitmapConfig);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      options.inPreferredColorSpace = colorSpace == null
+              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
+    }
     final CloseableReference<PooledByteBuffer> bytesRef = encodedImage.getByteBufferRef();
     Preconditions.checkNotNull(bytesRef);
     try {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
@@ -7,6 +7,7 @@
 
 package com.facebook.imagepipeline.nativecode;
 
+import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.ColorSpace;
@@ -25,6 +26,7 @@ import com.facebook.imagepipeline.memory.BitmapCounterProvider;
 import com.facebook.imagepipeline.platform.PlatformDecoder;
 import com.facebook.imageutils.BitmapUtil;
 import com.facebook.imageutils.JfifUtil;
+import com.facebook.soloader.DoNotOptimize;
 import java.util.Locale;
 import javax.annotation.Nullable;
 
@@ -89,8 +91,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
         encodedImage.getSampleSize(),
         bitmapConfig);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      options.inPreferredColorSpace = colorSpace == null
-              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
+      OreoUtils.setColorSpace(options, colorSpace);
     }
     CloseableReference<PooledByteBuffer> bytesRef = encodedImage.getByteBufferRef();
     Preconditions.checkNotNull(bytesRef);
@@ -128,8 +129,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
         encodedImage.getSampleSize(),
         bitmapConfig);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      options.inPreferredColorSpace = colorSpace == null
-              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
+      OreoUtils.setColorSpace(options, colorSpace);
     }
     final CloseableReference<PooledByteBuffer> bytesRef = encodedImage.getByteBufferRef();
     Preconditions.checkNotNull(bytesRef);
@@ -188,6 +188,15 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
     return length >= 2 &&
         buffer.read(length - 2) == (byte) JfifUtil.MARKER_FIRST_BYTE &&
         buffer.read(length - 1) == (byte) JfifUtil.MARKER_EOI;
+  }
+
+  @DoNotOptimize
+  private static class OreoUtils {
+    @TargetApi(Build.VERSION_CODES.O)
+    static void setColorSpace(BitmapFactory.Options options, ColorSpace colorSpace) {
+      options.inPreferredColorSpace = colorSpace == null
+              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
+    }
   }
 
   /**

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/DefaultDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/DefaultDecoder.java
@@ -71,7 +71,7 @@ public abstract class DefaultDecoder implements PlatformDecoder {
   @Override
   public CloseableReference<Bitmap> decodeFromEncodedImage(
       EncodedImage encodedImage, Bitmap.Config bitmapConfig, @Nullable Rect regionToDecode) {
-    return decodeFromEncodedImageWithColorSpace(encodedImage, bitmapConfig, regionToDecode, false);
+    return decodeFromEncodedImageWithColorSpace(encodedImage, bitmapConfig, regionToDecode, null);
   }
 
   @Override
@@ -81,7 +81,7 @@ public abstract class DefaultDecoder implements PlatformDecoder {
       @Nullable Rect regionToDecode,
       int length) {
     return decodeJPEGFromEncodedImageWithColorSpace(
-        encodedImage, bitmapConfig, regionToDecode, length, false);
+        encodedImage, bitmapConfig, regionToDecode, length, null);
   }
 
   /**
@@ -91,7 +91,9 @@ public abstract class DefaultDecoder implements PlatformDecoder {
    * @param bitmapConfig the {@link android.graphics.Bitmap.Config} used to create the decoded
    *     Bitmap
    * @param regionToDecode optional image region to decode or null to decode the whole image
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @exception java.lang.OutOfMemoryError if the Bitmap cannot be allocated
    */
@@ -100,16 +102,16 @@ public abstract class DefaultDecoder implements PlatformDecoder {
       EncodedImage encodedImage,
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
-      final boolean transformToSRGB) {
+      @Nullable final ColorSpace colorSpace) {
     final BitmapFactory.Options options = getDecodeOptionsForStream(encodedImage, bitmapConfig);
     boolean retryOnFail = options.inPreferredConfig != Bitmap.Config.ARGB_8888;
     try {
       return decodeFromStream(
-          encodedImage.getInputStream(), options, regionToDecode, transformToSRGB);
+          encodedImage.getInputStream(), options, regionToDecode, colorSpace);
     } catch (RuntimeException re) {
       if (retryOnFail) {
         return decodeFromEncodedImageWithColorSpace(
-            encodedImage, Bitmap.Config.ARGB_8888, regionToDecode, transformToSRGB);
+            encodedImage, Bitmap.Config.ARGB_8888, regionToDecode, colorSpace);
       }
       throw re;
     }
@@ -123,7 +125,9 @@ public abstract class DefaultDecoder implements PlatformDecoder {
    *     Bitmap
    * @param regionToDecode optional image region to decode or null to decode the whole image
    * @param length the number of encoded bytes in the buffer
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @exception java.lang.OutOfMemoryError if the Bitmap cannot be allocated
    */
@@ -133,7 +137,7 @@ public abstract class DefaultDecoder implements PlatformDecoder {
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
       int length,
-      final boolean transformToSRGB) {
+      @Nullable final ColorSpace colorSpace) {
     boolean isJpegComplete = encodedImage.isCompleteAt(length);
     final BitmapFactory.Options options = getDecodeOptionsForStream(encodedImage, bitmapConfig);
     InputStream jpegDataStream = encodedImage.getInputStream();
@@ -149,11 +153,11 @@ public abstract class DefaultDecoder implements PlatformDecoder {
     }
     boolean retryOnFail = options.inPreferredConfig != Bitmap.Config.ARGB_8888;
     try {
-      return decodeFromStream(jpegDataStream, options, regionToDecode, transformToSRGB);
+      return decodeFromStream(jpegDataStream, options, regionToDecode, colorSpace);
     } catch (RuntimeException re) {
       if (retryOnFail) {
         return decodeJPEGFromEncodedImageWithColorSpace(
-            encodedImage, Bitmap.Config.ARGB_8888, regionToDecode, length, transformToSRGB);
+            encodedImage, Bitmap.Config.ARGB_8888, regionToDecode, length, colorSpace);
       }
       throw re;
     }
@@ -169,7 +173,7 @@ public abstract class DefaultDecoder implements PlatformDecoder {
    */
   protected CloseableReference<Bitmap> decodeStaticImageFromStream(
       InputStream inputStream, BitmapFactory.Options options, @Nullable Rect regionToDecode) {
-    return decodeFromStream(inputStream, options, regionToDecode, false);
+    return decodeFromStream(inputStream, options, regionToDecode, null);
   }
 
   /**
@@ -178,14 +182,16 @@ public abstract class DefaultDecoder implements PlatformDecoder {
    * @param inputStream the InputStream
    * @param options the {@link android.graphics.BitmapFactory.Options} used to decode the stream
    * @param regionToDecode optional image region to decode or null to decode the whole image
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    */
   private CloseableReference<Bitmap> decodeFromStream(
       InputStream inputStream,
       BitmapFactory.Options options,
       @Nullable Rect regionToDecode,
-      final boolean transformToSRGB) {
+      @Nullable final ColorSpace colorSpace) {
     Preconditions.checkNotNull(inputStream);
     int targetWidth = options.outWidth;
     int targetHeight = options.outHeight;
@@ -218,9 +224,10 @@ public abstract class DefaultDecoder implements PlatformDecoder {
     //noinspection ConstantConditions
     options.inBitmap = bitmapToReuse;
 
-    // Performs transformation at load time to sRGB.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && transformToSRGB) {
-      options.inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB);
+    // Performs transformation at load time to target color space.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      options.inPreferredColorSpace = colorSpace == null
+              ? ColorSpace.get(ColorSpace.Named.SRGB) : colorSpace;
     }
 
     Bitmap decodedBitmap = null;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/PlatformDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/platform/PlatformDecoder.java
@@ -7,6 +7,7 @@
 package com.facebook.imagepipeline.platform;
 
 import android.graphics.Bitmap;
+import android.graphics.ColorSpace;
 import android.graphics.Rect;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -64,7 +65,9 @@ public interface PlatformDecoder {
    * @param bitmapConfig the {@link android.graphics.Bitmap.Config} used to create the decoded
    *     Bitmap
    * @param regionToDecode optional image region to decode or null to decode the whole image
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @throws TooManyBitmapsException if the pool is full
    * @throws java.lang.OutOfMemoryError if the Bitmap cannot be allocated
@@ -73,7 +76,7 @@ public interface PlatformDecoder {
       final EncodedImage encodedImage,
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
-      final boolean transformToSRGB);
+      @Nullable final ColorSpace colorSpace);
 
   /**
    * Creates a bitmap from encoded JPEG bytes. Supports a partial JPEG image. In addition, a region
@@ -85,7 +88,9 @@ public interface PlatformDecoder {
    *     Bitmap
    * @param regionToDecode optional image region to decode or null to decode the whole image.
    * @param length the number of encoded bytes in the buffer
-   * @param transformToSRGB whether to allow color space transformation to sRGB at load time
+   * @param colorSpace the target color space of the decoded bitmap, must be one of the named
+   *                   color space in {@link android.graphics.ColorSpace.Named}. If null, then SRGB
+   *                   color space is assumed if the SDK version >= 26.
    * @return the bitmap
    * @throws TooManyBitmapsException if the pool is full
    * @throws java.lang.OutOfMemoryError if the Bitmap cannot be allocated
@@ -95,5 +100,5 @@ public interface PlatformDecoder {
       Bitmap.Config bitmapConfig,
       @Nullable Rect regionToDecode,
       int length,
-      final boolean transformToSRGB);
+      @Nullable final ColorSpace colorSpace);
 }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imagepipeline/ImagePipelineRegionDecodingFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imagepipeline/ImagePipelineRegionDecodingFragment.java
@@ -164,7 +164,7 @@ public class ImagePipelineRegionDecodingFragment extends BaseShowcaseFragment {
         ImageDecodeOptions options) {
       CloseableReference<Bitmap> decodedBitmapReference =
           mPlatformDecoder.decodeJPEGFromEncodedImageWithColorSpace(
-              encodedImage, options.bitmapConfig, mRegion, length, options.transformToSRGB);
+              encodedImage, options.bitmapConfig, mRegion, length, options.colorSpace);
       try {
         return new CloseableStaticBitmap(decodedBitmapReference, qualityInfo, 0);
       } finally {


### PR DESCRIPTION
Color management was introduced in Android O. Currently Fresco allows
applications to specify whether a decoded bitmap should be transformed to SRGB
color space or not at load time, and legacy APIs pass in false, meaning if
applications don't use newer APIs, the decoded bitmap will have the encoded
color space as the final color space if they have one. This doesn't not align
with the world before Android O because before Android O, everything is
essentially treated as SRGB inside the rendering pipeline no matter whether the
images come with a color space.

This patch, 1) Modifies the newer APIs to accept ColorSpace instead of a
boolean, a more future-proof solution as mobile display technology evolves; 2)
Updates legacy APIs to pass in null, meaning on newer devices (API level >=
26), applications that haven't managed color will always get the decoded bitmap
in SRGB color space.

Issue: #2318
