### PR TITLE
Fix invalid gif image cause crash

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DefaultImageDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/decoder/DefaultImageDecoder.java
@@ -132,6 +132,10 @@ public class DefaultImageDecoder implements ImageDecoder {
       final int length,
       final QualityInfo qualityInfo,
       final ImageDecodeOptions options) {
+    if (encodedImage.getWidth() == EncodedImage.UNKNOWN_WIDTH
+        || encodedImage.getHeight() == EncodedImage.UNKNOWN_HEIGHT) {
+      throw new DecodeException("image width or height is incorrect", encodedImage);
+    }
     if (!options.forceStaticImage && mAnimatedGifDecoder != null) {
       return mAnimatedGifDecoder.decode(encodedImage, length, qualityInfo, options);
     }


### PR DESCRIPTION
## Motivation (required)

when we want use lib to get and show invalid gif image, it's will crash on release version.
Gif url:
https://glip-vault-1.s3-accelerate.amazonaws.com/web/customer_files/1164984672268/FFD95CE6-F8D5-498D-BF86-E6A817B16EBA_zxc.gif?Expires=2075494478&AWSAccessKeyId=AKIAJROPQDFTIHBTLJJQ&Signature=huivGKdOrIMJYhHrOq6fut2p9Ns%3D&response-content-disposition=attachment

## Test Plan (required)

Has already tested by our QA team.

## Next Steps
 