### PR TITLE
Support progressive animated webp

### DIFF
--- a/animated-base/src/main/java/com/facebook/fresco/animation/factory/ExperimentalBitmapAnimationDrawableFactory.java
+++ b/animated-base/src/main/java/com/facebook/fresco/animation/factory/ExperimentalBitmapAnimationDrawableFactory.java
@@ -9,6 +9,7 @@ package com.facebook.fresco.animation.factory;
 
 import android.graphics.Bitmap;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import com.facebook.cache.common.CacheKey;
 import com.facebook.common.internal.Supplier;
@@ -35,17 +36,22 @@ import com.facebook.imagepipeline.animated.impl.AnimatedDrawableBackendProvider;
 import com.facebook.imagepipeline.animated.impl.AnimatedFrameCache;
 import com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory;
 import com.facebook.imagepipeline.cache.CountingMemoryCache;
+import com.facebook.imagepipeline.drawable.BaseDrawableFactory;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableAnimatedImage;
 import com.facebook.imagepipeline.image.CloseableImage;
+import com.facebook.imagepipeline.image.EncodedImage;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+
+import javax.annotation.Nullable;
 
 /**
  * Animation factory for {@link AnimatedDrawable2}.
  *
  */
-public class ExperimentalBitmapAnimationDrawableFactory implements DrawableFactory {
+public class ExperimentalBitmapAnimationDrawableFactory extends BaseDrawableFactory {
 
   public static final int CACHING_STRATEGY_NO_CACHE = 0;
   public static final int CACHING_STRATEGY_FRESCO_CACHE = 1;
@@ -90,6 +96,22 @@ public class ExperimentalBitmapAnimationDrawableFactory implements DrawableFacto
     return new AnimatedDrawable2(
         createAnimationBackend(
             ((CloseableAnimatedImage) image).getImageResult()));
+  }
+
+  @Nullable
+  @Override
+  public Drawable createDrawable(Drawable previousDrawable, CloseableImage image) {
+    if (previousDrawable instanceof AnimatedDrawable2) {
+      ((AnimatedDrawable2) previousDrawable).updateProgressiveAnimation(
+        createAnimationBackend(((CloseableAnimatedImage) image).getImageResult()));
+      return previousDrawable;
+    }
+    return null;
+  }
+
+  @Override
+  public boolean needPreviousDrawable(Drawable previousDrawable, CloseableImage image) {
+    return previousDrawable instanceof AnimatedDrawable2;
   }
 
   private AnimationBackend createAnimationBackend(AnimatedImageResult animatedImageResult) {

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImage.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImage.java
@@ -97,4 +97,13 @@ public interface AnimatedImage {
    * @return the frame info
    */
   AnimatedDrawableFrameInfo getFrameInfo(int frameNumber);
+
+  /**
+   * Return whether the image is partial. This may be due to a cancellation or failure while the
+   * file was being downloaded or because only part of the image was requested or only part of image
+   * has been downloaded for the time being.
+   *
+   * @return whether the image is partial
+   */
+  boolean isPartial();
 }

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableBackendImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/impl/AnimatedDrawableBackendImpl.java
@@ -91,7 +91,7 @@ public class AnimatedDrawableBackendImpl implements AnimatedDrawableBackend {
 
   @Override
   public int getLoopCount() {
-    return mAnimatedImage.getLoopCount();
+    return mAnimatedImage.isPartial() ? 1 : mAnimatedImage.getLoopCount();
   }
 
   @Override

--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/frame/DropFramesFrameScheduler.java
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/frame/DropFramesFrameScheduler.java
@@ -27,6 +27,10 @@ public class DropFramesFrameScheduler implements FrameScheduler {
   @Override
   public int getFrameNumberToRender(long animationTimeMs, long lastFrameTimeMs) {
     if (!isInfiniteAnimation()) {
+      long loopDurationMs = getLoopDurationMs();
+      if (loopDurationMs == 0) {
+        return FRAME_NUMBER_DONE;
+      }
       long loopCount = animationTimeMs / getLoopDurationMs();
       if (loopCount >= mAnimationInformation.getLoopCount()) {
         return FRAME_NUMBER_DONE;

--- a/animated-gif-lite/src/main/java/com/facebook/animated/giflite/draw/MovieAnimatedImage.java
+++ b/animated-gif-lite/src/main/java/com/facebook/animated/giflite/draw/MovieAnimatedImage.java
@@ -92,5 +92,10 @@ public class MovieAnimatedImage implements AnimatedImage {
         AnimatedDrawableFrameInfo.BlendOperation.BLEND_WITH_PREVIOUS,
         mFrames[frameNumber].getDisposalMode());
   }
+
+  @Override
+  public boolean isPartial() {
+    return false;
+  }
 }
 

--- a/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
+++ b/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
@@ -188,6 +188,11 @@ public class GifImage implements AnimatedImage, AnimatedImageDecoder {
     }
   }
 
+  @Override
+  public boolean isPartial() {
+    return false;
+  }
+
   private static AnimatedDrawableFrameInfo.DisposalMethod fromGifDisposalMethod(int disposalMode) {
     if (disposalMode == 0 /* DISPOSAL_UNSPECIFIED */) {
       return AnimatedDrawableFrameInfo.DisposalMethod.DISPOSE_DO_NOT;

--- a/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
+++ b/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
@@ -169,6 +169,11 @@ public class WebPImage implements AnimatedImage, AnimatedImageDecoder {
     }
   }
 
+  @Override
+  public boolean isPartial() {
+    return nativeGetPartial();
+  }
+
   private static native WebPImage nativeCreateFromDirectByteBuffer(ByteBuffer buffer);
   private static native WebPImage nativeCreateFromNativeMemory(long nativePtr, int sizeInBytes);
   private native int nativeGetWidth();
@@ -179,6 +184,7 @@ public class WebPImage implements AnimatedImage, AnimatedImageDecoder {
   private native int nativeGetLoopCount();
   private native WebPFrame nativeGetFrame(int frameNumber);
   private native int nativeGetSizeInBytes();
+  private native boolean nativeGetPartial();
   private native void nativeDispose();
   private native void nativeFinalize();
 }

--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DefaultDrawableFactory.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/DefaultDrawableFactory.java
@@ -12,6 +12,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.media.ExifInterface;
 import com.facebook.drawee.drawable.OrientedDrawable;
+import com.facebook.imagepipeline.drawable.BaseDrawableFactory;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.CloseableStaticBitmap;
@@ -19,7 +20,7 @@ import com.facebook.imagepipeline.image.EncodedImage;
 import com.facebook.imagepipeline.systrace.FrescoSystrace;
 import javax.annotation.Nullable;
 
-public class DefaultDrawableFactory implements DrawableFactory {
+public class DefaultDrawableFactory extends BaseDrawableFactory {
 
   private final Resources mResources;
   private final @Nullable DrawableFactory mAnimatedDrawableFactory;
@@ -65,6 +66,21 @@ public class DefaultDrawableFactory implements DrawableFactory {
       if (FrescoSystrace.isTracing()) {
         FrescoSystrace.endSection();
       }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Drawable createDrawable(Drawable previousDrawable, CloseableImage image) {
+    return mAnimatedDrawableFactory.createDrawable(previousDrawable, image);
+  }
+
+  @Override
+  public boolean needPreviousDrawable(Drawable previousDrawable, CloseableImage image) {
+    if (mAnimatedDrawableFactory != null && mAnimatedDrawableFactory.supportsImageType(image)) {
+      return mAnimatedDrawableFactory.needPreviousDrawable(previousDrawable, image);
+    } else {
+      return false;
     }
   }
 

--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/PipelineDraweeController.java
@@ -269,7 +269,9 @@ public class PipelineDraweeController
         return drawable;
       }
 
-      drawable = mDefaultDrawableFactory.createDrawable(closeableImage);
+      drawable = mDefaultDrawableFactory.needPreviousDrawable(mDrawable, closeableImage)
+        ? mDefaultDrawableFactory.createDrawable(mDrawable, closeableImage)
+        : mDefaultDrawableFactory.createDrawable(closeableImage);
       if (drawable != null) {
         return drawable;
       }
@@ -288,7 +290,9 @@ public class PipelineDraweeController
     }
     for (DrawableFactory factory : drawableFactories) {
       if (factory.supportsImageType(closeableImage)) {
-        Drawable drawable = factory.createDrawable(closeableImage);
+        Drawable drawable = factory.needPreviousDrawable(mDrawable, closeableImage)
+          ? factory.createDrawable(mDrawable, closeableImage)
+          : factory.createDrawable(closeableImage);
         if (drawable != null) {
           return drawable;
         }

--- a/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
@@ -96,7 +96,7 @@ public abstract class AbstractDraweeController<T, INFO> implements
   private @Nullable String mContentDescription;
   private @Nullable DataSource<T> mDataSource;
   private @Nullable T mFetchedImage;
-  private @Nullable Drawable mDrawable;
+  protected @Nullable Drawable mDrawable;
   private boolean mJustConstructed = true;
 
   public AbstractDraweeController(

--- a/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeControllerBuilder.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeControllerBuilder.java
@@ -37,6 +37,24 @@ public abstract class AbstractDraweeControllerBuilder <
     INFO>
     implements SimpleDraweeControllerBuilder {
 
+  private static class ProgressiveAnimationsListener extends BaseControllerListener<Object> {
+    private AbstractDraweeController mAbstractDraweeController;
+
+    void setAbstractDraweeController(AbstractDraweeController abstractDraweeController) {
+      mAbstractDraweeController = abstractDraweeController;
+    }
+
+    @Override
+    public void onIntermediateImageSet(String id, @Nullable Object imageInfo) {
+      if (mAbstractDraweeController != null && mAbstractDraweeController.getAnimatable() != null) {
+        mAbstractDraweeController.getAnimatable().start();
+      }
+    }
+  }
+
+  private static final ProgressiveAnimationsListener sProgressiveAnimationsListener
+    = new ProgressiveAnimationsListener();
+
   private static final ControllerListener<Object> sAutoPlayAnimationsListener =
       new BaseControllerListener<Object>() {
         @Override
@@ -423,6 +441,8 @@ public abstract class AbstractDraweeControllerBuilder <
     if (mAutoPlayAnimations) {
       controller.addControllerListener(sAutoPlayAnimationsListener);
     }
+    sProgressiveAnimationsListener.setAbstractDraweeController(controller);
+    controller.addControllerListener(sProgressiveAnimationsListener);
   }
 
   /** Installs a retry manager (if specified) to the given controller. */

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/BaseDrawableFactory.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/BaseDrawableFactory.java
@@ -1,0 +1,32 @@
+package com.facebook.imagepipeline.drawable;
+
+import android.graphics.drawable.Drawable;
+
+import com.facebook.imagepipeline.image.CloseableImage;
+
+import javax.annotation.Nullable;
+
+public class BaseDrawableFactory implements DrawableFactory {
+
+  @Override
+  public boolean supportsImageType(CloseableImage image) {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public Drawable createDrawable(CloseableImage image) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Drawable createDrawable(Drawable previousDrawable, CloseableImage image) {
+    return null;
+  }
+
+  @Override
+  public boolean needPreviousDrawable(Drawable previousDrawable, CloseableImage image) {
+    return false;
+  }
+}

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/DrawableFactory.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/drawable/DrawableFactory.java
@@ -33,4 +33,26 @@ public interface DrawableFactory {
    */
   @Nullable
   Drawable createDrawable(CloseableImage image);
+
+  /**
+   * Create or update a drawable for the given image and the previous drawable.
+   * It is guaranteed that this method is only called if
+   * {@link #needPreviousDrawable(Drawable, CloseableImage)} returned true.
+   *
+   * @param previousDrawable the previous drawable
+   * @param image the image to create the drawable for
+   * @return the Drawable for the image and previous drawable or null if an error occurred
+   */
+  @Nullable
+  Drawable createDrawable(Drawable previousDrawable, CloseableImage image);
+
+  /**
+   * Returns true if the factory need previous drawable to create or update a Drawable for the given
+   * image.
+   *
+   * @param previousDrawable the previous drawable
+   * @param image the image to check
+   * @return true if previous drawable is needed
+   */
+  boolean needPreviousDrawable(Drawable previousDrawable, CloseableImage image);
 }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/DecodeProducer.java
@@ -237,8 +237,10 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
 
     /** Performs the decode synchronously. */
     private void doDecode(EncodedImage encodedImage, @Status int status) {
-      // do not run for partial results of anything except JPEG
-      if (encodedImage.getImageFormat() != DefaultImageFormats.JPEG && isNotLast(status)) {
+      // do not run for partial results of anything except JPEG and WEBP_ANIMATED
+      if (encodedImage.getImageFormat() != DefaultImageFormats.JPEG
+        && encodedImage.getImageFormat() != DefaultImageFormats.WEBP_ANIMATED
+        && isNotLast(status)) {
         return;
       }
 
@@ -272,7 +274,7 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
             : getIntermediateImageEndOffset(encodedImage);
         QualityInfo quality = isLastAndComplete || isPlaceholder
             ? ImmutableQualityInfo.FULL_QUALITY
-            : getQualityInfo();
+            : getQualityInfo(encodedImage);
 
         mProducerListener.onProducerStart(mProducerContext.getId(), PRODUCER_NAME);
         CloseableImage image = null;
@@ -423,7 +425,7 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
 
     protected abstract int getIntermediateImageEndOffset(EncodedImage encodedImage);
 
-    protected abstract QualityInfo getQualityInfo();
+    protected abstract QualityInfo getQualityInfo(EncodedImage encodedImage);
   }
 
   private class LocalImagesProgressiveDecoder extends ProgressiveDecoder {
@@ -450,7 +452,7 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
     }
 
     @Override
-    protected QualityInfo getQualityInfo() {
+    protected QualityInfo getQualityInfo(EncodedImage encodedImag) {
       return ImmutableQualityInfo.of(0, false, false);
     }
   }
@@ -502,12 +504,20 @@ public class DecodeProducer implements Producer<CloseableReference<CloseableImag
 
     @Override
     protected int getIntermediateImageEndOffset(EncodedImage encodedImage) {
-      return mProgressiveJpegParser.getBestScanEndOffset();
+      if (encodedImage.getImageFormat() == DefaultImageFormats.JPEG) {
+        return mProgressiveJpegParser.getBestScanEndOffset();
+      } else {
+        return encodedImage.getSize();
+      }
     }
 
     @Override
-    protected QualityInfo getQualityInfo() {
-      return mProgressiveJpegConfig.getQualityInfo(mProgressiveJpegParser.getBestScanNumber());
+    protected QualityInfo getQualityInfo(EncodedImage encodedImage) {
+      if (encodedImage.getImageFormat() == DefaultImageFormats.JPEG) {
+        return mProgressiveJpegConfig.getQualityInfo(mProgressiveJpegParser.getBestScanNumber());
+      } else {
+        return ImmutableQualityInfo.FULL_QUALITY;
+      }
     }
   }
 }

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/color/ColorImageExample.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/color/ColorImageExample.java
@@ -20,6 +20,7 @@ import com.facebook.imageformat.ImageFormat;
 import com.facebook.imageformat.ImageFormatCheckerUtils;
 import com.facebook.imagepipeline.common.ImageDecodeOptions;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
+import com.facebook.imagepipeline.drawable.BaseDrawableFactory;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -178,7 +179,7 @@ public class ColorImageExample {
    * Color drawable factory that is able to render a {@link CloseableColorImage} by creating
    * a new {@link ColorDrawable} for the given color.
    */
-  public static class ColorDrawableFactory implements DrawableFactory {
+  public static class ColorDrawableFactory extends BaseDrawableFactory {
 
     @Override
     public boolean supportsImageType(CloseableImage image) {

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/keyframes/KeyframesDecoderExample.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/keyframes/KeyframesDecoderExample.java
@@ -18,6 +18,7 @@ import com.facebook.imageformat.ImageFormat;
 import com.facebook.imageformat.ImageFormatCheckerUtils;
 import com.facebook.imagepipeline.common.ImageDecodeOptions;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
+import com.facebook.imagepipeline.drawable.BaseDrawableFactory;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -149,7 +150,7 @@ public class KeyframesDecoderExample {
     }
   }
 
-  private static class KeyframesDrawableFactory implements DrawableFactory {
+  private static class KeyframesDrawableFactory extends BaseDrawableFactory {
 
     @Override
     public boolean supportsImageType(CloseableImage image) {

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/svg/SvgDecoderExample.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/svg/SvgDecoderExample.java
@@ -20,6 +20,7 @@ import com.facebook.imageformat.ImageFormat;
 import com.facebook.imageformat.ImageFormatCheckerUtils;
 import com.facebook.imagepipeline.common.ImageDecodeOptions;
 import com.facebook.imagepipeline.decoder.ImageDecoder;
+import com.facebook.imagepipeline.drawable.BaseDrawableFactory;
 import com.facebook.imagepipeline.drawable.DrawableFactory;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.EncodedImage;
@@ -131,7 +132,7 @@ public class SvgDecoderExample {
   /**
    * SVG drawable factory that creates {@link PictureDrawable}s for SVG images.
    */
-  public static class SvgDrawableFactory implements DrawableFactory {
+  public static class SvgDrawableFactory extends BaseDrawableFactory {
 
     @Override
     public boolean supportsImageType(CloseableImage image) {

--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webp/ImageFormatWebpFragment.java
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/imageformat/webp/ImageFormatWebpFragment.java
@@ -25,6 +25,8 @@ import com.facebook.drawee.view.SimpleDraweeView;
 import com.facebook.fresco.samples.showcase.BaseShowcaseFragment;
 import com.facebook.fresco.samples.showcase.R;
 import com.facebook.fresco.samples.showcase.misc.CheckerBoardDrawable;
+import com.facebook.imagepipeline.request.ImageRequest;
+import com.facebook.imagepipeline.request.ImageRequestBuilder;
 
 /**
  * This fragment displays different WebP images.
@@ -65,12 +67,29 @@ public class ImageFormatWebpFragment extends BaseShowcaseFragment {
     });
 
     final SimpleDraweeView draweeWebpAnimated = view.findViewById(R.id.drawee_view_webp_animated);
+    ImageRequest request = ImageRequestBuilder.newBuilderWithSource(sampleUris().createWebpAnimatedUri())
+            .setProgressiveRenderingEnabled(false).build();
     draweeWebpAnimated.setController(
         Fresco.newDraweeControllerBuilder()
             .setAutoPlayAnimations(true)
             .setOldController(draweeWebpAnimated.getController())
-            .setUri(sampleUris().createWebpAnimatedUri())
+            .setImageRequest(request)
             .build());
+
+    final SwitchCompat switchProgressive = view.findViewById(R.id.switch_progressive_animator);
+    switchProgressive.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+      @Override
+      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+        ImageRequest request = ImageRequestBuilder.newBuilderWithSource(sampleUris().createWebpAnimatedUri())
+          .setProgressiveRenderingEnabled(isChecked).build();
+        draweeWebpAnimated.setController(
+          Fresco.newDraweeControllerBuilder()
+            .setAutoPlayAnimations(true)
+            .setOldController(draweeWebpAnimated.getController())
+            .setImageRequest(request)
+            .build());
+      }
+    });
 
     final TextView supportStatusTextView = view.findViewById(R.id.text_webp_support_status);
     final StringBuilder sb = new StringBuilder();

--- a/samples/showcase/src/main/res/layout/fragment_format_webp.xml
+++ b/samples/showcase/src/main/res/layout/fragment_format_webp.xml
@@ -71,6 +71,14 @@
         android:textAppearance="?android:attr/textAppearanceSmall"
         />
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/switch_progressive_animator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:text="@string/format_switch_checker_progressive_animator"
+        />
+
     <!-- webp support status -->
 
     <TextView

--- a/samples/showcase/src/main/res/values/strings.xml
+++ b/samples/showcase/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
   <string name="category_format">Image Format</string>
 
   <string name="format_switch_checker_board">Checker board background</string>
+  <string name="format_switch_checker_progressive_animator">Checker progressive animator</string>
   <string name="format_switch_aspect_ratio">Portrait aspect ratio</string>
 
   <string-array name="gif_decoder_options">


### PR DESCRIPTION
## Motivation

To support progressive animated webp, so that Fresco can play animation while download the image.

- change ```WebPDemux``` to ```WebPDemuxPartial``` in webp.cpp
- modify the ```DecodeProducer``` to decode intermediate webp data
- Although multiple ClosableImage will be generated during the download, I still only use one ```AnimatedDrawable2```. So I modified ```AnimatedDrawable2``` to support playing from the last frame played by the previous data, and added ```createDrawable(Drawable previousDrawable, CloseableImage image)``` to ```DrawableFactory``` to update Drawable instead of creating a new Drawable
- add a ```ControllerListener``` to ```AbstractDraweeController``` to start animation every time data arrives

## Test Plan

We can use ```ImageRequestBuilder.setProgressiveRenderingEnabled``` to enable the progressive animated webp. I add a switch to ```ImageFormatWebpFragment``` in SHOWCASE module so that we can test the function.
```final SwitchCompat switchProgressive = view.findViewById(R.id.switch_progressive_animator);
    switchProgressive.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
      @Override
      public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
        ImageRequest request = ImageRequestBuilder.newBuilderWithSource(sampleUris().createWebpAnimatedUri())
          .setProgressiveRenderingEnabled(isChecked).build();
        draweeWebpAnimated.setController(
          Fresco.newDraweeControllerBuilder()
            .setAutoPlayAnimations(true)
            .setOldController(draweeWebpAnimated.getController())
            .setImageRequest(request)
            .build());
      }
    });
```

First, we construct a weak network environment, by modifying the proxy configuration or modifying the code of NetworkFetchProducer, and then turning on the switch, we can see that some frames can be played before the image is completely downloaded.