### PR TITLE
Animated drawable2 bugfix

### DIFF
--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/AnimatedDrawable2.java
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/AnimatedDrawable2.java
@@ -228,7 +228,6 @@ public class AnimatedDrawable2 extends Drawable implements Animatable, DrawableW
             targetRenderTimeForNextFrameMs + mFrameSchedulingDelayMs;
         scheduleNextFrame(scheduledRenderTimeForNextFrameMs);
       }else{
-        frameNumberToDraw = mAnimationBackend.getFrameCount() - 1;
         mAnimationListener.onAnimationStop(this);
         mIsRunning = false;
       }

--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/AnimatedDrawable2.java
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/AnimatedDrawable2.java
@@ -227,6 +227,10 @@ public class AnimatedDrawable2 extends Drawable implements Animatable, DrawableW
         scheduledRenderTimeForNextFrameMs =
             targetRenderTimeForNextFrameMs + mFrameSchedulingDelayMs;
         scheduleNextFrame(scheduledRenderTimeForNextFrameMs);
+      }else{
+        frameNumberToDraw = mAnimationBackend.getFrameCount() - 1;
+        mAnimationListener.onAnimationStop(this);
+        mIsRunning = false;
       }
     }
 


### PR DESCRIPTION
## Motivation

As #2205 comments, sometimes AnimatedDrawable2 finish playing animation without calling onAnimationStop.
I read the source code and find out that in AnimatedDrawable2.java line 221-230:
```
long actualRenderTimeEnd = now();   
if (mIsRunning) {  
      // Schedule the next frame if needed.
    targetRenderTimeForNextFrameMs =
          mFrameScheduler.getTargetRenderTimeForNextFrameMs(actualRenderTimeEnd - mStartTimeMs);
    if (targetRenderTimeForNextFrameMs != FrameScheduler.NO_NEXT_TARGET_RENDER_TIME) {
         scheduledRenderTimeForNextFrameMs =
            targetRenderTimeForNextFrameMs + mFrameSchedulingDelayMs;
         scheduleNextFrame(scheduledRenderTimeForNextFrameMs);
     }
} 
```
If animation still running but actualRenderTimeEnd - mStartTimeMs is larger than loopDurationMs, there will not be scheduleNextFrame, so onAnimationStop will not be calling.
To fix this bug, I added few lines in the 'else' branch:
```
    long actualRenderTimeEnd = now();
    if (mIsRunning) {
      // Schedule the next frame if needed.
      targetRenderTimeForNextFrameMs =
          mFrameScheduler.getTargetRenderTimeForNextFrameMs(actualRenderTimeEnd - mStartTimeMs);
      if (targetRenderTimeForNextFrameMs != FrameScheduler.NO_NEXT_TARGET_RENDER_TIME) {
        scheduledRenderTimeForNextFrameMs =
            targetRenderTimeForNextFrameMs + mFrameSchedulingDelayMs;
        scheduleNextFrame(scheduledRenderTimeForNextFrameMs);
      }else{
        mAnimationListener.onAnimationStop(this);
        mIsRunning = false;
      }

```
If there is no next frame, the animation is finished, so onAnimationStop should be called and mIsRunning should be false.
## Test Plan (required)

Unfortunately, we can not reproduce the problem every time, but I assume that when the frame interval is vary small such as 1ms, this problem can be reproduced easily.

