### PR TITLE
Enable multidex for the showcase build

### DIFF
--- a/samples/showcase/build.gradle
+++ b/samples/showcase/build.gradle
@@ -16,6 +16,7 @@ android {
         minSdkVersion rootProject.ext.samplesMinSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
+        multiDexEnabled true
         versionName "${VERSION_NAME}"
 
         testApplicationId "com.facebook.fresco.samples.showcase.test"
@@ -79,6 +80,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:${versions.androidx.recyclerview}"
     implementation "androidx.cardview:cardview:1.0.0"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
+    implementation "androidx.multidex:multidex:2.0.1"
 
     implementation "com.google.android.material:material:1.1.0-alpha03"
     implementation "com.facebook.stetho:stetho-okhttp3:${STETHO_VERSION}"

--- a/samples/showcase/build.gradle
+++ b/samples/showcase/build.gradle
@@ -16,7 +16,6 @@ android {
         minSdkVersion rootProject.ext.samplesMinSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        multiDexEnabled true
         versionName "${VERSION_NAME}"
 
         testApplicationId "com.facebook.fresco.samples.showcase.test"
@@ -48,10 +47,12 @@ android {
     flavorDimensions "main"
     productFlavors {
         normal {
+            multiDexEnabled true
         }
         instantRunConfig {
             dimension "main"
             minSdkVersion 21
+            multiDexEnabled false
         }
         internal {
         }


### PR DESCRIPTION
The day has come:

```
* What went wrong:
Execution failed for task ':samples:showcase:mergeDexNormalDebug'.
> com.android.build.api.transform.TransformException: java.lang.RuntimeException: java.lang.RuntimeException: com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives:
  The number of method references in a .dex file cannot exceed 64K.
  Learn how to resolve this issue at https://developer.android.com/tools/building/multidex.html
```

```
66246 > 65536
```

Test Plan:

```
./gradlew :samples:showcase:installNormalDebug
```

Now worky.

![Screenshot_1560944736](https://user-images.githubusercontent.com/9906/59762882-2a0dbc80-9290-11e9-902b-4cc4f12af469.png)
