### PR TITLE
Fix thumbnail image orientation

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/EncodedImage.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/image/EncodedImage.java
@@ -365,7 +365,7 @@ public class EncodedImage implements Closeable {
         && mRotationAngle == UNKNOWN_ROTATION_ANGLE) {
       mExifOrientation = HeifExifUtil.getOrientation(getInputStream());
       mRotationAngle = JfifUtil.getAutoRotateAngleFromOrientation(mExifOrientation);
-    } else {
+    } else if (mRotationAngle == UNKNOWN_ROTATION_ANGLE) {
       mRotationAngle = 0;
     }
   }


### PR DESCRIPTION
Summary:
Some images are displayed with an incorrect orientation. The orientation in Exif is correct and the image itself is just a selfie. Another selfie from the same phone is shown correctly and generally about 2 selfies out of 10 are shown with the wrong orientation.

I'm not completely certain how this happens, but there seems like a race condition between caching and resizing: in some images EncodedImage.parseMetaData gets to work on the full image, so it is able to read the orientation value from Exif, while for some images, parseMetaData is called when the image already has mRotationAngle set (by going through copyMetaDataFrom from the just-made cache maybe?)

Regardless, it seems logical that the image orientation should only be reset if it isn't set already.

This possibly fixes this issue as well: https://github.com/facebook/fresco/issues/2119

Reviewed By: oprisnik

Differential Revision: D16460898

