### PR TITLE
Change method name 'generate' to 'createJpeg', 'increase' to 'includeBitmap', 'ensure' to 'loadLibrary', 'build' to 'getImageRequest', 'get' to 'createContext'

### DIFF
--- a/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
+++ b/animated-gif/src/main/java/com/facebook/animated/gif/GifImage.java
@@ -36,7 +36,7 @@ public class GifImage implements AnimatedImage, AnimatedImageDecoder {
   @DoNotStrip
   private long mNativeContext;
 
-  private static synchronized void ensure() {
+  private static synchronized void loadLibrary() {
     if (!sInitialized) {
       sInitialized = true;
       SoLoader.loadLibrary("gifimage");
@@ -50,7 +50,7 @@ public class GifImage implements AnimatedImage, AnimatedImageDecoder {
    * @param source the data to the image (a copy will be made)
    */
   public static GifImage create(byte[] source) {
-    ensure();
+    loadLibrary();
     Preconditions.checkNotNull(source);
 
     ByteBuffer byteBuffer = ByteBuffer.allocateDirect(source.length);
@@ -67,14 +67,14 @@ public class GifImage implements AnimatedImage, AnimatedImageDecoder {
    * @param byteBuffer the ByteBuffer containing the image (a copy will be made)
    */
   public static GifImage create(ByteBuffer byteBuffer) {
-    ensure();
+    loadLibrary();
     byteBuffer.rewind();
 
     return nativeCreateFromDirectByteBuffer(byteBuffer);
   }
 
   public static GifImage create(long nativePtr, int sizeInBytes) {
-    ensure();
+    loadLibrary();
     Preconditions.checkArgument(nativePtr != 0);
     return nativeCreateFromNativeMemory(nativePtr, sizeInBytes);
   }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/EmptyJpegGenerator.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/EmptyJpegGenerator.java
@@ -162,7 +162,7 @@ public class EmptyJpegGenerator {
     mPooledByteBufferFactory = pooledByteBufferFactory;
   }
 
-  public CloseableReference<PooledByteBuffer> generate(short width, short height) {
+  public CloseableReference<PooledByteBuffer> createJpeg(short width, short height) {
     PooledByteBufferOutputStream os = null;
     try {
       os = mPooledByteBufferFactory.newOutputStream(

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/HoneycombBitmapCreator.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/HoneycombBitmapCreator.java
@@ -36,7 +36,7 @@ public class HoneycombBitmapCreator implements BitmapCreator {
   @Override
   public Bitmap createNakedBitmap(
       int width, int height, Bitmap.Config bitmapConfig) {
-    CloseableReference<PooledByteBuffer> jpgRef = mJpegGenerator.generate(
+    CloseableReference<PooledByteBuffer> jpgRef = mJpegGenerator.createJpeg(
         (short) width,
         (short) height);
     EncodedImage encodedImage = null;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/HoneycombBitmapFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/bitmaps/HoneycombBitmapFactory.java
@@ -62,7 +62,7 @@ public class HoneycombBitmapFactory extends PlatformBitmapFactory {
     if (mImmutableBitmapFallback) {
       return createFallbackBitmap(width, height, bitmapConfig);
     }
-    CloseableReference<PooledByteBuffer> jpgRef = mJpegGenerator.generate(
+    CloseableReference<PooledByteBuffer> jpgRef = mJpegGenerator.createJpeg(
         (short) width,
         (short) height);
     try {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
@@ -8,16 +8,11 @@
 package com.facebook.imagepipeline.memory;
 
 import android.graphics.Bitmap;
-import android.os.Build;
+
 import com.facebook.common.internal.Preconditions;
-import com.facebook.common.internal.Throwables;
-import com.facebook.common.references.CloseableReference;
 import com.facebook.common.references.ResourceReleaser;
-import com.facebook.imagepipeline.common.TooManyBitmapsException;
-import com.facebook.imagepipeline.nativecode.Bitmaps;
 import com.facebook.imageutils.BitmapUtil;
-import java.util.ArrayList;
-import java.util.List;
+
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -59,7 +54,7 @@ public class BitmapCounter {
    * @param bitmap to include in the count
    * @return true if and only if bitmap is successfully included in the count
    */
-  public synchronized boolean increase(Bitmap bitmap) {
+  public synchronized boolean isInBitmap(Bitmap bitmap) {
     final int bitmapSize = BitmapUtil.getSizeInBytes(bitmap);
     if (mCount >= mMaxCount || mSize + bitmapSize > mMaxSize) {
       return false;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/memory/BitmapCounter.java
@@ -54,7 +54,7 @@ public class BitmapCounter {
    * @param bitmap to include in the count
    * @return true if and only if bitmap is successfully included in the count
    */
-  public synchronized boolean isInBitmap(Bitmap bitmap) {
+  public synchronized boolean includeBitmap(Bitmap bitmap) {
     final int bitmapSize = BitmapUtil.getSizeInBytes(bitmap);
     if (mCount >= mMaxCount || mSize + bitmapSize > mMaxSize) {
       return false;

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
@@ -216,7 +216,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
       bitmap.recycle();
       throw Throwables.propagate(e);
     }
-    if (!mUnpooledBitmapsCounter.increase(bitmap)) {
+    if (!mUnpooledBitmapsCounter.isInBitmap(bitmap)) {
       int bitmapSize = BitmapUtil.getSizeInBytes(bitmap);
       bitmap.recycle();
       String detailMessage = String.format(

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/nativecode/DalvikPurgeableDecoder.java
@@ -216,7 +216,7 @@ public abstract class DalvikPurgeableDecoder implements PlatformDecoder {
       bitmap.recycle();
       throw Throwables.propagate(e);
     }
-    if (!mUnpooledBitmapsCounter.isInBitmap(bitmap)) {
+    if (!mUnpooledBitmapsCounter.includeBitmap(bitmap)) {
       int bitmapSize = BitmapUtil.getSizeInBytes(bitmap);
       bitmap.recycle();
       String detailMessage = String.format(

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/memory/BitmapCounterTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/memory/BitmapCounterTest.java
@@ -32,9 +32,9 @@ public class BitmapCounterTest {
   @Test
   public void testBasic() {
     assertState(0, 0);
-    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(1)));
+    assertTrue(mBitmapCounter.includeBitmap(bitmapForSize(1)));
     assertState(1, 1);
-    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(2)));
+    assertTrue(mBitmapCounter.includeBitmap(bitmapForSize(2)));
     assertState(2, 3);
     mBitmapCounter.decrease(bitmapForSize(1));
     assertState(1, 2);
@@ -42,43 +42,43 @@ public class BitmapCounterTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testDecreaseTooMuch() {
-    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(1)));
+    assertTrue(mBitmapCounter.includeBitmap(bitmapForSize(1)));
     mBitmapCounter.decrease(bitmapForSize(2));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testDecreaseTooMany() {
-    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(2)));
+    assertTrue(mBitmapCounter.includeBitmap(bitmapForSize(2)));
     mBitmapCounter.decrease(bitmapForSize(1));
     mBitmapCounter.decrease(bitmapForSize(1));
   }
 
   @Test
   public void testMaxSize() {
-    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(MAX_SIZE)));
+    assertTrue(mBitmapCounter.includeBitmap(bitmapForSize(MAX_SIZE)));
     assertState(1, MAX_SIZE);
   }
 
   @Test
   public void testMaxCount() {
     for (int i = 0; i < MAX_COUNT; ++i) {
-      mBitmapCounter.isInBitmap(bitmapForSize(1));
+      mBitmapCounter.includeBitmap(bitmapForSize(1));
     }
     assertState(MAX_COUNT, MAX_COUNT);
   }
 
   @Test()
   public void increaseTooBigObject() {
-    assertFalse(mBitmapCounter.isInBitmap(bitmapForSize(MAX_SIZE + 1)));
+    assertFalse(mBitmapCounter.includeBitmap(bitmapForSize(MAX_SIZE + 1)));
     assertState(0, 0);
   }
 
   @Test()
   public void increaseTooManyObjects() {
     for (int i = 0; i < MAX_COUNT; ++i) {
-      mBitmapCounter.isInBitmap(bitmapForSize(1));
+      mBitmapCounter.includeBitmap(bitmapForSize(1));
     }
-    assertFalse(mBitmapCounter.isInBitmap(bitmapForSize(1)));
+    assertFalse(mBitmapCounter.includeBitmap(bitmapForSize(1)));
     assertState(MAX_COUNT, MAX_COUNT);
   }
 

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/memory/BitmapCounterTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/memory/BitmapCounterTest.java
@@ -32,9 +32,9 @@ public class BitmapCounterTest {
   @Test
   public void testBasic() {
     assertState(0, 0);
-    assertTrue(mBitmapCounter.increase(bitmapForSize(1)));
+    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(1)));
     assertState(1, 1);
-    assertTrue(mBitmapCounter.increase(bitmapForSize(2)));
+    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(2)));
     assertState(2, 3);
     mBitmapCounter.decrease(bitmapForSize(1));
     assertState(1, 2);
@@ -42,43 +42,43 @@ public class BitmapCounterTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testDecreaseTooMuch() {
-    assertTrue(mBitmapCounter.increase(bitmapForSize(1)));
+    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(1)));
     mBitmapCounter.decrease(bitmapForSize(2));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testDecreaseTooMany() {
-    assertTrue(mBitmapCounter.increase(bitmapForSize(2)));
+    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(2)));
     mBitmapCounter.decrease(bitmapForSize(1));
     mBitmapCounter.decrease(bitmapForSize(1));
   }
 
   @Test
   public void testMaxSize() {
-    assertTrue(mBitmapCounter.increase(bitmapForSize(MAX_SIZE)));
+    assertTrue(mBitmapCounter.isInBitmap(bitmapForSize(MAX_SIZE)));
     assertState(1, MAX_SIZE);
   }
 
   @Test
   public void testMaxCount() {
     for (int i = 0; i < MAX_COUNT; ++i) {
-      mBitmapCounter.increase(bitmapForSize(1));
+      mBitmapCounter.isInBitmap(bitmapForSize(1));
     }
     assertState(MAX_COUNT, MAX_COUNT);
   }
 
   @Test()
   public void increaseTooBigObject() {
-    assertFalse(mBitmapCounter.increase(bitmapForSize(MAX_SIZE + 1)));
+    assertFalse(mBitmapCounter.isInBitmap(bitmapForSize(MAX_SIZE + 1)));
     assertState(0, 0);
   }
 
   @Test()
   public void increaseTooManyObjects() {
     for (int i = 0; i < MAX_COUNT; ++i) {
-      mBitmapCounter.increase(bitmapForSize(1));
+      mBitmapCounter.isInBitmap(bitmapForSize(1));
     }
-    assertFalse(mBitmapCounter.increase(bitmapForSize(1)));
+    assertFalse(mBitmapCounter.isInBitmap(bitmapForSize(1)));
     assertState(MAX_COUNT, MAX_COUNT);
   }
 

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/platform/KitKatPurgeableDecoderTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/platform/KitKatPurgeableDecoderTest.java
@@ -169,7 +169,7 @@ public class KitKatPurgeableDecoderTest {
   @Test(expected = TooManyBitmapsException.class)
   public void testHitBitmapLimit_static() {
     assumeNotNull(mKitKatPurgeableDecoder);
-    mBitmapCounter.increase(
+    mBitmapCounter.isInBitmap(
         MockBitmapFactory.createForSize(MAX_BITMAP_SIZE, DEFAULT_BITMAP_CONFIG));
     try {
       mKitKatPurgeableDecoder.decodeFromEncodedImage(mEncodedImage, DEFAULT_BITMAP_CONFIG, null);

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/platform/KitKatPurgeableDecoderTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/platform/KitKatPurgeableDecoderTest.java
@@ -169,7 +169,7 @@ public class KitKatPurgeableDecoderTest {
   @Test(expected = TooManyBitmapsException.class)
   public void testHitBitmapLimit_static() {
     assumeNotNull(mKitKatPurgeableDecoder);
-    mBitmapCounter.isInBitmap(
+    mBitmapCounter.includeBitmap(
         MockBitmapFactory.createForSize(MAX_BITMAP_SIZE, DEFAULT_BITMAP_CONFIG));
     try {
       mKitKatPurgeableDecoder.decodeFromEncodedImage(mEncodedImage, DEFAULT_BITMAP_CONFIG, null);

--- a/samples/comparison/src/main/java/com/facebook/samples/comparison/MainActivity.java
+++ b/samples/comparison/src/main/java/com/facebook/samples/comparison/MainActivity.java
@@ -411,7 +411,7 @@ public class MainActivity extends AppCompatActivity {
           ImageSize.ORIGINAL_IMAGE);
     }
     ImageUrlsFetcher.getImageUrls(
-        builder.build(),
+        builder.getImageRequest(),
         new ImageUrlsFetcher.Callback() {
           @Override
           public void onFinish(List<String> result) {

--- a/samples/comparison/src/main/java/com/facebook/samples/comparison/urlsfetcher/ImageUrlsRequestBuilder.java
+++ b/samples/comparison/src/main/java/com/facebook/samples/comparison/urlsfetcher/ImageUrlsRequestBuilder.java
@@ -39,7 +39,7 @@ public class ImageUrlsRequestBuilder {
     return this;
   }
 
-  public ImageUrlsRequest build() {
+  public ImageUrlsRequest getImageRequest() {
     ImageUrlsRequest request = new ImageUrlsRequest(mEndpointUrl, mRequestedImageFormats);
     mRequestedImageFormats = null;
     return request;

--- a/vito/litho/src/main/java/com/facebook/fresco/vito/litho/FrescoVitoImageSpec.java
+++ b/vito/litho/src/main/java/com/facebook/fresco/vito/litho/FrescoVitoImageSpec.java
@@ -206,7 +206,7 @@ public class FrescoVitoImageSpec {
     if (contextOverride != null) {
       return contextOverride;
     }
-    return DefaultFrescoContext.get(context.getResources());
+    return DefaultFrescoContext.createContext(context.getResources());
   }
 
   static FrescoController getController(

--- a/vito/provider/src/main/java/com/facebook/fresco/vito/provider/DefaultFrescoContext.java
+++ b/vito/provider/src/main/java/com/facebook/fresco/vito/provider/DefaultFrescoContext.java
@@ -28,7 +28,7 @@ public class DefaultFrescoContext {
   private static @Nullable FrescoContext sInstance;
   private static @Nullable Supplier<Boolean> sDebugOverlayEnabledSupplier;
 
-  public static synchronized FrescoContext get(Resources resources) {
+  public static synchronized FrescoContext createContext(Resources resources) {
     if (sInstance == null) {
       initialize(resources, null);
     }


### PR DESCRIPTION
The class EmptyJpegGenerator is used to generate an empty JPEG image.  This method named "generate" is to create a new JPEG image. Thus, the method name "createJpeg" is more intuitive than "generate".

The class BitmapCounter is used to count the Bitmaps.  This method named "increase" is to check the bitmap. Thus, the method name "includeBitmap" is more intuitive than "increase".

The class BitmapCounter is used to represent GifImage.  This method named 'ensure' is to load library for image processing. Thus, the method name 'loadLibrary' is more intuitive than 'ensure'.

The class ImageUrlsRequestBuilder is used to build ImageUrlsRequest.  This method named 'build' is to get a new Image url request. Thus, the method name 'getImageRequest' is more intuitive than 'build'.

The class DefaultFrescoContext  is used to represent DefaultFrescoContext.  This method named 'get' is to create a context. Thus, the method name 'createContext' is more precise than 'get'.