### PR TITLE
Fix build failure for the proguard warnings on Mac OS.

### DIFF
--- a/samples/showcase/proguard-showcase.pro
+++ b/samples/showcase/proguard-showcase.pro
@@ -5,3 +5,19 @@
 -keep class com.facebook.drawee.generic.GenericDraweeHierarchy {
     boolean hasImage();
 }
+
+-dontwarn com.squareup.leakcanary.**
+
+-dontwarn android.text.StaticLayout
+-dontwarn android.view.DisplayList
+-dontwarn android.view.RenderNode
+-dontwarn android.view.DisplayListCanvas
+-dontwarn android.view.HardwareCanvas
+-dontwarn android.view.GLES20DisplayList
+
+-dontwarn com.facebook.fbui.**
+-dontwarn com.facebook.litho.**
+
+-keep class org.mozilla.** { *; }
+-dontwarn org.mozilla.javascript.**
+-dontwarn org.mozilla.classfile.**


### PR DESCRIPTION
## Motivation (required)

The proguard warnings make the build failed in the Mac OS.

## Test Plan (required)

The request don't change the logic and doesn't need test. 
