### PR TITLE
Make sure there is at least one overlay in GenericDraweeHierarchy

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
+++ b/drawee/src/main/java/com/facebook/drawee/generic/GenericDraweeHierarchy.java
@@ -109,6 +109,13 @@ public class GenericDraweeHierarchy implements SettableDraweeHierarchy {
     mActualImageWrapper = new ForwardingDrawable(mEmptyActualImageDrawable);
 
     int numOverlays = (builder.getOverlays() != null) ? builder.getOverlays().size() : 1;
+
+    // make sure there is at least one overlay to make setOverlayImage(Drawable)
+    // method work.
+    if (numOverlays == 0) {
+      numOverlays = 1;
+    }
+
     numOverlays += (builder.getPressedStateOverlay() != null) ? 1 : 0;
 
     // layer indices and count

--- a/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/generic/GenericDraweeHierarchyTest.java
@@ -26,6 +26,8 @@ import com.facebook.drawee.drawable.Rounded;
 import com.facebook.drawee.drawable.RoundedBitmapDrawable;
 import com.facebook.drawee.drawable.RoundedCornersDrawable;
 import com.facebook.drawee.drawable.ScaleTypeDrawable;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Test;
@@ -953,6 +955,20 @@ public class GenericDraweeHierarchyTest {
   @Test
   public void testSetRoundingParams_RoundedLeafsToRoundedLeafs() {
     testSetRoundingParams_ToRoundedLeafsFrom(RoundingParams.fromCornersRadius(10));
+  }
+
+  @Test
+  public void testSetOverlaysImages() {
+    GenericDraweeHierarchy dh = mBuilder.setOverlays(new ArrayList<Drawable>()).build();
+
+    Drawable drawable = DrawableTestUtils.mockDrawable();
+    dh.setOverlayImage(drawable);
+
+    try {
+      dh.setOverlayImage(1, drawable);
+    } catch (Exception e) {
+      assertTrue(e instanceof IllegalArgumentException);
+    }
   }
 
   private void testSetRoundingParams_ToRoundedLeafsFrom(RoundingParams prev) {


### PR DESCRIPTION
## Motivation (required)

Make sure there is at least one layer on `GenericDraweeHierarchy` to make `setOverlayImage(Drawable)` work without crashing.

There has a logic above to make sure the hierarchy has at least one layer if the `getOverlays()` method from builder returns null:

```
int numOverlays = (builder.getOverlays() != null) ? builder.getOverlays().size() : 1;
```

But no check for the situation where `builder.getOverlays()` gets empty.

`setOverlayImage(Drawable)` should always be functional while `setOverlayImage(int, Drawable)` is not.

By adding this feature we can make sure that users can call `setOverlayImage(Drawable)` without worrying crash.

## Test Plan (required)

A unit test method has been added within this PR.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
