### PR TITLE
Update Giflib to 5.1.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ VOLLEY_VERSION=1.1.0
 # Deps for native libraries
 LIBJPEG_TURBO_VERSION=1.5.3
 LIBPNG_VERSION=1.6.35
-GIFLIB_VERSION=5.1.4
+GIFLIB_VERSION=5.1.8
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
 LIBWEBP_VERSION=1.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ VOLLEY_VERSION=1.1.0
 # Deps for native libraries
 LIBJPEG_TURBO_VERSION=1.5.3
 LIBPNG_VERSION=1.6.35
-GIFLIB_VERSION=5.1.8
+GIFLIB_VERSION=5.1.9
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
 LIBWEBP_VERSION=1.0.0
 


### PR DESCRIPTION
## Motivation (required)

GifLib 5.1.4 has a known security issue documented here: https://nvd.nist.gov/vuln/detail/CVE-2019-15133

GifLib 5.1.8+ contains the fix for this issue. 5.1.8 was not found on launchpad.net so we can use 5.1.9.

## Test Plan (required)

Just a minor library upgrade, just ensure it builds and runs normally.

## Next Steps

Sign the [CLA][2], if you haven't already: SIGNED