### PR TITLE
Fixed resource leak problem while using BlurPostProcessor

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/filter/RenderScriptBlurFilter.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/filter/RenderScriptBlurFilter.java
@@ -54,6 +54,10 @@ public abstract class RenderScriptBlurFilter {
       blurScript.setInput(allIn);
       blurScript.forEach(allOut);
       allOut.copyTo(dest);
+
+      blurScript.destroy();
+      allIn.destroy();
+      allOut.destroy();
     } finally {
       if (rs != null) {
         rs.destroy();


### PR DESCRIPTION
## Motivation

To fix StrictMode resource leak warnings while using `com.facebook.imagepipeline.postprocessors.BlurPostProcessor`

RenderScript components which inherits `android.renderscript.BaseObj` must be destroyed after use, but it wasn't in `com.facebook.imagepipeline.filter.RenderScriptBlurFilter`.
This will cause StrictMode warnings in Google Pixel 3 with Android 10 as follows: 

```
Caused by: java.lang.Throwable: Explicit termination method 'destroy' not called
    at dalvik.system.CloseGuard.open(CloseGuard.java:237)
    at android.renderscript.Allocation.<init>(Allocation.java:421)
    at android.renderscript.Allocation.<init>(Allocation.java:425)
    at android.renderscript.Allocation.createFromBitmap(Allocation.java:2823)
    at android.renderscript.Allocation.createFromBitmap(Allocation.java:3063)
    at com.facebook.imagepipeline.filter.RenderScriptBlurFilter.blurBitmap(RenderScriptBlurFilter.java:49)
    at com.facebook.imagepipeline.postprocessors.BlurPostProcessor.process(BlurPostProcessor.java:67)
    at com.facebook.imagepipeline.request.BasePostprocessor.process(BasePostprocessor.java:61)
    at com.facebook.imagepipeline.producers.PostprocessorProducer$PostprocessorConsumer.postprocessInternal(PostprocessorProducer.java:247)
    at com.facebook.imagepipeline.producers.PostprocessorProducer$PostprocessorConsumer.doPostprocessing(PostprocessorProducer.java:217)
    at com.facebook.imagepipeline.producers.PostprocessorProducer$PostprocessorConsumer.access$600(PostprocessorProducer.java:73)
    at com.facebook.imagepipeline.producers.PostprocessorProducer$PostprocessorConsumer$2.run(PostprocessorProducer.java:175)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at com.facebook.imagepipeline.core.PriorityThreadFactory$1.run(PriorityThreadFactory.java:51)
    at java.lang.Thread.run(Thread.java:919) 
```

Currently this problem happens in Fresco version *2.0.0* and *2.1.0*. No preceded versions were tested.

## Test Plan
We can reproduce the phenomenon by using this code.

```
import com.facebook.imagepipeline.postprocessors.BlurPostProcessor

fun SimpleDraweeView.setBlur(uri: Uri) {
  this.controller = Fresco.newDraweeControllerBuilder()
    .setOldController(controller)
      .setImageRequest(
        ImageRequestBuilder.newBuilderWithSource(uri)
          .setPostprocessor(BlurPostProcessor(RenderScriptBlurFilter.BLUR_MAX_RADIUS, context))
          .build()
      ).build()
}
```


Applying this change does not cause any more StrictMode warnings.

Please review this change. Thanks in advance.

