### PR TITLE
fix #2497

### DIFF
--- a/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
+++ b/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java
@@ -164,30 +164,26 @@ public abstract class AbstractDataSource<T> implements DataSource<T> {
     }
 
     if (shouldNotify) {
-      notifyDataSubscriber(dataSubscriber, executor, hasFailed(), wasCancelled());
+      notifyDataSubscriber(dataSubscriber, executor);
     }
   }
 
   private void notifyDataSubscribers() {
-    final boolean isFailure = hasFailed();
-    final boolean isCancellation = wasCancelled();
     for (Pair<DataSubscriber<T>, Executor> pair : mSubscribers) {
-      notifyDataSubscriber(pair.first, pair.second, isFailure, isCancellation);
+      notifyDataSubscriber(pair.first, pair.second);
     }
   }
 
   protected void notifyDataSubscriber(
       final DataSubscriber<T> dataSubscriber,
-      final Executor executor,
-      final boolean isFailure,
-      final boolean isCancellation) {
+      final Executor executor) {
     Runnable runnable =
         new Runnable() {
           @Override
           public void run() {
-            if (isFailure) {
+            if (AbstractDataSource.this.hasFailed()) {
               dataSubscriber.onFailure(AbstractDataSource.this);
-            } else if (isCancellation) {
+            } else if (AbstractDataSource.this.wasCancelled()) {
               dataSubscriber.onCancellation(AbstractDataSource.this);
             } else {
               dataSubscriber.onNewResult(AbstractDataSource.this);


### PR DESCRIPTION
## Motivation

fix #2497 

![image](https://user-images.githubusercontent.com/16160722/82018020-f5c89900-96b6-11ea-8447-5d277b084fb6.png)

The reason for the problem is that runnable's execution is asynchronous, and `com.facebook.datasource.AbstractDataSource#mDataSourceStatus` may change during this time.

Because the first execution to [this line](https://github.com/facebook/fresco/blob/master/fbcore/src/main/java/com/facebook/datasource/AbstractDataSource.java#L193) will eventually result in the mDataSource being [null](https://github.com/facebook/fresco/blob/master/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java#L628), even though the two fields are the same on the second execution (line 5 of the log), the method returns false because the mDataSource is null, resulting in the onFailure method not being called([this method](https://github.com/facebook/fresco/blob/master/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java#L602) will return false).