### PR TITLE
permit developer customizing a implementation of  SerialExecutorService

### DIFF
--- a/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
+++ b/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
@@ -54,7 +54,7 @@ public class AnimatedFactoryV2Impl implements AnimatedFactory {
   private @Nullable AnimatedDrawableBackendProvider mAnimatedDrawableBackendProvider;
   private @Nullable AnimatedDrawableUtil mAnimatedDrawableUtil;
   private @Nullable DrawableFactory mAnimatedDrawableFactory;
-  SerialExecutorService mSerialExecutorService;
+  private @Nullable SerialExecutorService mSerialExecutorService;
 
   @DoNotStrip
   public AnimatedFactoryV2Impl(
@@ -67,7 +67,7 @@ public class AnimatedFactoryV2Impl implements AnimatedFactory {
     mExecutorSupplier = executorSupplier;
     mBackingCache = backingCache;
     mDownscaleFrameToDrawableDimensions = downscaleFrameToDrawableDimensions;
-    this.mSerialExecutorService = serialExecutorServiceForFramePreparing;
+    mSerialExecutorService = serialExecutorServiceForFramePreparing;
   }
 
   @Nullable

--- a/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
+++ b/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
@@ -54,17 +54,20 @@ public class AnimatedFactoryV2Impl implements AnimatedFactory {
   private @Nullable AnimatedDrawableBackendProvider mAnimatedDrawableBackendProvider;
   private @Nullable AnimatedDrawableUtil mAnimatedDrawableUtil;
   private @Nullable DrawableFactory mAnimatedDrawableFactory;
+  SerialExecutorService mSerialExecutorService;
 
   @DoNotStrip
   public AnimatedFactoryV2Impl(
       PlatformBitmapFactory platformBitmapFactory,
       ExecutorSupplier executorSupplier,
       CountingMemoryCache<CacheKey, CloseableImage> backingCache,
-      boolean downscaleFrameToDrawableDimensions) {
+      boolean downscaleFrameToDrawableDimensions,
+      SerialExecutorService serialExecutorServiceForFramePreparing) {
     mPlatformBitmapFactory = platformBitmapFactory;
     mExecutorSupplier = executorSupplier;
     mBackingCache = backingCache;
     mDownscaleFrameToDrawableDimensions = downscaleFrameToDrawableDimensions;
+    this.mSerialExecutorService = serialExecutorServiceForFramePreparing;
   }
 
   @Nullable
@@ -114,8 +117,8 @@ public class AnimatedFactoryV2Impl implements AnimatedFactory {
           }
         };
 
-    final SerialExecutorService serialExecutorServiceForFramePreparing =
-        new DefaultSerialExecutorService(mExecutorSupplier.forDecode());
+    final SerialExecutorService serialExecutorServiceForFramePreparing = mSerialExecutorService == null ?
+        new DefaultSerialExecutorService(mExecutorSupplier.forDecode()):mSerialExecutorService;
 
     Supplier<Integer> numberOfFramesToPrepareSupplier =
         new Supplier<Integer>() {

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
@@ -8,6 +8,7 @@
 package com.facebook.imagepipeline.animated.factory;
 
 import com.facebook.cache.common.CacheKey;
+import com.facebook.common.executors.SerialExecutorService;
 import com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory;
 import com.facebook.imagepipeline.cache.CountingMemoryCache;
 import com.facebook.imagepipeline.core.ExecutorSupplier;
@@ -24,7 +25,8 @@ public class AnimatedFactoryProvider {
       PlatformBitmapFactory platformBitmapFactory,
       ExecutorSupplier executorSupplier,
       CountingMemoryCache<CacheKey, CloseableImage> backingCache,
-      boolean downscaleFrameToDrawableDimensions) {
+      boolean downscaleFrameToDrawableDimensions,
+      SerialExecutorService serialExecutorService) {
     if (!sImplLoaded) {
       try {
         final Class<?> clazz =
@@ -34,14 +36,16 @@ public class AnimatedFactoryProvider {
                 PlatformBitmapFactory.class,
                 ExecutorSupplier.class,
                 CountingMemoryCache.class,
-                Boolean.TYPE);
+                Boolean.TYPE,
+                SerialExecutorService.class);
         sImpl =
             (AnimatedFactory)
                 constructor.newInstance(
                     platformBitmapFactory,
                     executorSupplier,
                     backingCache,
-                    downscaleFrameToDrawableDimensions);
+                    downscaleFrameToDrawableDimensions,
+                    serialExecutorService);
       } catch (Throwable e) {
         // Head in the sand
       }

--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedFactoryProvider.java
@@ -14,6 +14,7 @@ import com.facebook.imagepipeline.cache.CountingMemoryCache;
 import com.facebook.imagepipeline.core.ExecutorSupplier;
 import com.facebook.imagepipeline.image.CloseableImage;
 import java.lang.reflect.Constructor;
+import java.util.concurrent.ExecutorService;
 
 public class AnimatedFactoryProvider {
 
@@ -26,7 +27,7 @@ public class AnimatedFactoryProvider {
       ExecutorSupplier executorSupplier,
       CountingMemoryCache<CacheKey, CloseableImage> backingCache,
       boolean downscaleFrameToDrawableDimensions,
-      SerialExecutorService serialExecutorService) {
+      ExecutorService serialExecutorService) {
     if (!sImplLoaded) {
       try {
         final Class<?> clazz =

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -707,7 +707,7 @@ public class ImagePipelineConfig {
       return this;
     }
 
-    public Builder setSerialExecutorService(@Nullable SerialExecutorService serialExecutorService){
+    public Builder setExecutorServiceForAnimatedImages(@Nullable SerialExecutorService serialExecutorService){
       mSerialExecutorService = serialExecutorService;
       return this;
     }

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -723,7 +723,7 @@ public class ImagePipelineConfig {
     public Builder setExecutorServiceForAnimatedImages(
         @Nullable SerialExecutorService serialExecutorService){
       mSerialExecutorService = serialExecutorService;
-      return this
+      return this;
     }
     public Builder setBitmapMemoryCacheFactory(
         @Nullable BitmapMemoryCacheFactory bitmapMemoryCacheFactory) {

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineConfig.java
@@ -14,6 +14,7 @@ import android.os.Build;
 import com.facebook.cache.common.CacheKey;
 import com.facebook.cache.disk.DiskCacheConfig;
 import com.facebook.callercontext.CallerContextVerifier;
+import com.facebook.common.executors.SerialExecutorService;
 import com.facebook.common.internal.Preconditions;
 import com.facebook.common.internal.Supplier;
 import com.facebook.common.internal.VisibleForTesting;
@@ -109,6 +110,7 @@ public class ImagePipelineConfig {
   private final CloseableReferenceLeakTracker mCloseableReferenceLeakTracker;
   @Nullable private final MemoryCache<CacheKey, CloseableImage> mBitmapCache;
   @Nullable private final MemoryCache<CacheKey, PooledByteBuffer> mEncodedMemoryCache;
+  @Nullable private final SerialExecutorService mSerialExecutorService;
 
   private static DefaultImageRequestConfig sDefaultImageRequestConfig =
       new DefaultImageRequestConfig();
@@ -217,6 +219,7 @@ public class ImagePipelineConfig {
     mCloseableReferenceLeakTracker = builder.mCloseableReferenceLeakTracker;
     mBitmapCache = builder.mBitmapMemoryCache;
     mEncodedMemoryCache = builder.mEncodedMemoryCache;
+    mSerialExecutorService = builder.mSerialExecutorService;
     // Here we manage the WebpBitmapFactory implementation if any
     WebpBitmapFactory webpBitmapFactory = mImagePipelineExperiments.getWebpBitmapFactory();
     if (webpBitmapFactory != null) {
@@ -317,6 +320,10 @@ public class ImagePipelineConfig {
 
   public ExecutorSupplier getExecutorSupplier() {
     return mExecutorSupplier;
+  }
+
+  public SerialExecutorService getSerialExecutorService(){
+    return mSerialExecutorService;
   }
 
   public ImageCacheStatsTracker getImageCacheStatsTracker() {
@@ -505,6 +512,7 @@ public class ImagePipelineConfig {
         new NoOpCloseableReferenceLeakTracker();
     @Nullable private MemoryCache<CacheKey, CloseableImage> mBitmapMemoryCache;
     @Nullable private MemoryCache<CacheKey, PooledByteBuffer> mEncodedMemoryCache;
+    @Nullable private SerialExecutorService mSerialExecutorService;
 
     private Builder(Context context) {
       // Doesn't use a setter as always required.
@@ -696,6 +704,11 @@ public class ImagePipelineConfig {
     public Builder setEncodedMemoryCache(
         @Nullable MemoryCache<CacheKey, PooledByteBuffer> encodedMemoryCache) {
       mEncodedMemoryCache = encodedMemoryCache;
+      return this;
+    }
+
+    public Builder setSerialExecutorService(@Nullable SerialExecutorService serialExecutorService){
+      mSerialExecutorService = serialExecutorService;
       return this;
     }
 

--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/core/ImagePipelineFactory.java
@@ -179,7 +179,8 @@ public class ImagePipelineFactory {
               getPlatformBitmapFactory(),
               mConfig.getExecutorSupplier(),
               getBitmapCountingMemoryCache(),
-              mConfig.getExperiments().shouldDownscaleFrameToDrawableDimensions());
+              mConfig.getExperiments().shouldDownscaleFrameToDrawableDimensions(),
+              mConfig.getSerialExecutorService());
     }
     return mAnimatedFactory;
   }


### PR DESCRIPTION
## Motivation (required)
We found that fresco has a serious performance problem while side RecyclerView with a large number of animed webps.Then we check the source code and found the maxConcurrency in class DefaultSerialExecutorService is too small to excute tasks relate to (frame.renderFrame)

## Test Plan (required)
use foloowing url and you can recur issue http://cdn.poizon.com/algo/webp/62e595747d7279bbb497026487e1f735_dur124dur_1589537743359_w1080h1920_w480h672.webp 

new initialized code which can slove the issue

```
    val supplier = DefaultExecutorSupplier2(5)
    val pipelineConfig = ImagePipelineConfig.newBuilder(this)
            .setExecutorSupplier(supplier)
            .setSerialExecutorService(DefaultSerialExecutorService2(supplier.forDecode()))
        .build()
```

```
public class DefaultExecutorSupplier2 implements ExecutorSupplier {
  // Allows for simultaneous reads and writes.
  private static final int NUM_IO_BOUND_THREADS = 20;
  private static final int NUM_LIGHTWEIGHT_BACKGROUND_THREADS = 10;
……
```

```
public class DefaultSerialExecutorService2 extends ConstrainedExecutorService
    implements SerialExecutorService {

  public DefaultSerialExecutorService2(Executor executor) {
     // change the maxConcurrency to 5 or higher can improve the sliding performance clearly
    super("SerialExecutor", 5, executor, new LinkedBlockingQueue<Runnable>());
  }
```