### PR TITLE
Update libpng to address CVE-2019-7317

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ android.enableJetifier=true
 
 # Deps for native libraries
 LIBJPEG_TURBO_VERSION=1.5.3
+# When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
 LIBPNG_VERSION=1.6.37
 GIFLIB_VERSION=5.1.9
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk


### PR DESCRIPTION

Fixes: #2485

(P.S. Hope you're all doing well & staying safe :)).

Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid. 
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch

## Motivation (required)

libpng prior to 1.6.37 has a use-after-free issue (see CVE for details), so I'd like to bump the version number of the dependency to get the fix.

## Test Plan (required)

Diff is a single dependency bump, so existing tests will provide confidence that the two patch level version bump does not break any user facing behaviour.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
