### PR TITLE
Update giflib to address stack buffer overflow issue.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,12 +172,12 @@ subprojects {
             src libraryUrl
             onlyIfNewer true
             overwrite false
-            dest downloadsDir
+            dest "${downloadsDir}/${libraryFileName}"
             dependsOn createNativeDepsDirectories
         }
         // The unpack task
         tasks.create("unpack${name}", Copy) {
-            String filePath = "${downloadLibjpeg.dest}/${libraryFileName}"
+            String filePath = "${downloadsDir}/${libraryFileName}"
             ReadableResource resource
             if (filePath.endsWith("gz")) {
                 resource = resources.gzip(filePath)

--- a/build.gradle
+++ b/build.gradle
@@ -227,8 +227,8 @@ subprojects {
     // Gif
     createNativeLibrariesTasks(
             'Giflib',      // Name for the tasks
-            "https://launchpad.net/ubuntu/+archive/primary/+files/giflib_${GIFLIB_VERSION}.orig.tar.bz2", // The Url for download
-            "giflib_${GIFLIB_VERSION}.orig.tar.bz2", // The downloaded file
+            "https://sourceforge.net/projects/giflib/files/giflib-${GIFLIB_VERSION}.tar.gz/download", // The Url for download
+            "giflib-${GIFLIB_VERSION}.tar.gz", // The downloaded file
             'giflib', // The folder where the file is downloaded
             "giflib-${GIFLIB_VERSION}", // The first dir where we have put our customisation
             ['*.c', '*.h', '*.mk'], // Files to compile

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,6 @@ android.enableJetifier=true
 # Deps for native libraries
 LIBJPEG_TURBO_VERSION=1.5.3
 LIBPNG_VERSION=1.6.35
-GIFLIB_VERSION=5.1.9
+GIFLIB_VERSION=5.2.1
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
 LIBWEBP_VERSION=1.0.0


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch

## Motivation (required)

5.2.0 fixes a stack buffer overflow which can trigger a crash, but 5.2.0 was released when esr wasn't in a great state so 5.2.1 was released to address a couple of issues 5.2.0 created. So I'd like to bump the giflib version to 5.2.1 to get the fix in a healthy way.

Full details: https://sourceforge.net/p/giflib/code/ci/master/tree/NEWS

## Test Plan (required)

This is a dependency version bump, so CI and existing tests will verify there are no behavioural breaking changes.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
