### PR TITLE
Add Infer Annotations to testCompileOnly

### DIFF
--- a/animated-base/build.gradle
+++ b/animated-base/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api project(':animated-drawable')
     implementation Deps.Bolts.tasks
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation project(':animated-base-test')
     testImplementation project(':imagepipeline-test')
     testImplementation TestDeps.junit

--- a/animated-drawable/build.gradle
+++ b/animated-drawable/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     compileOnly Deps.jsr305
     compileOnly Deps.javaxAnnotation
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation Deps.AndroidX.androidxAnnotation
     testImplementation Deps.jsr305
     testImplementation TestDeps.junit

--- a/animated-gif/build.gradle
+++ b/animated-gif/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(':fbcore')
     implementation project(':animated-base')
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation project(':imagepipeline-base-test')
     testImplementation project(':imagepipeline-test')
     testImplementation TestDeps.junit

--- a/animated-webp/build.gradle
+++ b/animated-webp/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(':static-webp')
     implementation project(':animated-base')
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation project(':imagepipeline-base-test')
     testImplementation project(':imagepipeline-test')
     testImplementation TestDeps.junit

--- a/drawee/build.gradle
+++ b/drawee/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':ui-common')
     implementation project(':middleware')
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation Deps.jsr305
     testImplementation TestDeps.junit
     testImplementation TestDeps.mockitoCore

--- a/imagepipeline-base-test/build.gradle
+++ b/imagepipeline-base-test/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     implementation Deps.SoLoader.soloader
     implementation Deps.Bolts.tasks
     implementation project(':fbcore')
+
+    testCompileOnly Deps.inferAnnotation
 }
 apply from: rootProject.file('release.gradle')
 

--- a/imagepipeline-test/build.gradle
+++ b/imagepipeline-test/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compileOnly Deps.jsr305
     compileOnly Deps.javaxAnnotation
 
+    testCompileOnly Deps.inferAnnotation
     api project(':imagepipeline-base-test')
     implementation Deps.Bolts.tasks
     implementation project(':fbcore')


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch

## Motivation (required)

Currently the Infer annotations are only included in compileOnly dependencies which means that tests which refer to them end up with compilation warnings. 

Adding them to testCompileOnly as well means that enums values such as `Mode.STRICT` are also available to test code and so the compilation warnings are resolved.

## Test Plan (required)

Compilation in CI will show a reduction of "warning: unknown enum constant Mode.STRICT" messages

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
