### PR TITLE
Fix issues caused by use of FB internal things

### DIFF
--- a/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
+++ b/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
@@ -8,7 +8,7 @@
 object FrescoConfig {
   const val buildToolsVersion = "29.0.3"
 
-  const val compileSdkVersion = 28
+  const val compileSdkVersion = 29
   const val minSdkVersion = 14
   const val samplesMinSdkVersion = 15
   const val targetSdkVersion = 28

--- a/drawee/build.gradle
+++ b/drawee/build.gradle
@@ -26,9 +26,13 @@ dependencies {
     implementation project(':ui-common')
     implementation project(':middleware')
 
+    testCompileOnly Deps.inferAnnotation
     testImplementation Deps.jsr305
     testImplementation TestDeps.junit
     testImplementation TestDeps.mockitoCore
+    testImplementation(TestDeps.Powermock.apiMockito) {
+        exclude group: 'org.mockito', module: 'mockito-all'
+    }
     testImplementation(TestDeps.robolectric) {
         exclude group: 'commons-logging', module: 'commons-logging'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'

--- a/drawee/src/test/java/com/facebook/drawee/components/DeferredReleaserStressTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/components/DeferredReleaserStressTest.java
@@ -17,9 +17,11 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricTestRunner.class)
+@LooperMode(LooperMode.Mode.LEGACY) // Required for pausing and unpausing looper
 public class DeferredReleaserStressTest {
   private static final int K = 1000;
 

--- a/drawee/src/test/java/com/facebook/drawee/drawable/FadeDrawableOnFadeListenerTest.java
+++ b/drawee/src/test/java/com/facebook/drawee/drawable/FadeDrawableOnFadeListenerTest.java
@@ -17,14 +17,14 @@ import android.graphics.Canvas;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.SystemClock;
-import com.facebook.testing.robolectric.v4.WithTestDefaultsRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.robolectric.RobolectricTestRunner;
 
 /** Tests {@link FadeDrawable.OnFadeListener} */
-@RunWith(WithTestDefaultsRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @PrepareForTest({
   //  SystemClock.class,
   Rect.class,

--- a/fbcore/build.gradle
+++ b/fbcore/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compileOnly Deps.javaxAnnotation
     compileOnly Deps.AndroidX.androidxAnnotation
 
+    testImplementation Deps.inferAnnotation
     testImplementation project(':mockito-config')
     testImplementation Deps.jsr305
     testImplementation TestDeps.junit

--- a/fbcore/src/test/java/com/facebook/common/executors/HandlerExecutorServiceImplTest.java
+++ b/fbcore/src/test/java/com/facebook/common/executors/HandlerExecutorServiceImplTest.java
@@ -18,10 +18,12 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
+@LooperMode(LooperMode.Mode.LEGACY) // Required for pausing and unpausing the looper
 public class HandlerExecutorServiceImplTest {
 
   private AtomicInteger mCounter = new AtomicInteger();

--- a/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/PriorityNetworkFetcherTest.java
+++ b/imagepipeline/src/test/java/com/facebook/imagepipeline/producers/PriorityNetworkFetcherTest.java
@@ -531,7 +531,7 @@ public class PriorityNetworkFetcherTest {
 
     assertThat(recordingNetworkFetcher.createdFetchStates).hasSize(1);
     assertThat(fetchState.delegatedState)
-        .isSameAs(recordingNetworkFetcher.createdFetchStates.get(0));
+        .isSameInstanceAs(recordingNetworkFetcher.createdFetchStates.get(0));
 
     // Simulate a failure in fetchState, triggering a requeue.
     getOnlyElement(recordingNetworkFetcher.callbacks.get(fetchState.delegatedState))
@@ -539,7 +539,7 @@ public class PriorityNetworkFetcherTest {
 
     assertThat(recordingNetworkFetcher.createdFetchStates).hasSize(2);
     assertThat(fetchState.delegatedState)
-        .isSameAs(recordingNetworkFetcher.createdFetchStates.get(1));
+        .isSameInstanceAs(recordingNetworkFetcher.createdFetchStates.get(1));
 
     Map<String, String> extrasMap = fetcher.getExtraMap(fetchState, 123);
     assertThat(extrasMap).containsEntry("requeueCount", "1");

--- a/samples/gestures/build.gradle
+++ b/samples/gestures/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     implementation project(':drawee-backends:drawee-pipeline')
 
+    testImplementation Deps.inferAnnotation
     testImplementation TestDeps.junit
     testImplementation TestDeps.mockitoCore
     testImplementation(TestDeps.robolectric) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch

## Motivation (required)

A test class was added in commit 9aa485d75152a2d3ce63639e61acfb850759ff15 (FB internal D24799754) which relies on FB internal classes and configuration to compile, this meant that the GitHub PR verification action would fail the compilation test due to not having these resources available. This PR replaces the internal stuff with things available to the GitHub verification action;

* WithTestDefaultsRunner is an internal Facebook test runner which is unavailable in this repo, so I've replaced it with the Robolectric runner
* PowerMock wasn't in the build.gradle dependencies (but is probably in the BUCK dependencies internally), so I've added it.

Fixes: #2567

## Test Plan (required)

If this compiles and the tests completes we're all good.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
