### PR TITLE
Update SoLoader to v0.10.0

### DIFF
--- a/buildSrc/src/main/java/com/facebook/fresco/buildsrc/dependencies.kt
+++ b/buildSrc/src/main/java/com/facebook/fresco/buildsrc/dependencies.kt
@@ -50,7 +50,7 @@ object Deps {
   }
 
   object SoLoader {
-    private const val version = "0.9.0"
+    private const val version = "0.10.0"
     const val soloaderAnnotation = "com.facebook.soloader:annotation:$version"
     const val nativeloader = "com.facebook.soloader:nativeloader:$version"
     const val soloader = "com.facebook.soloader:soloader:$version"

--- a/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/Fresco.java
+++ b/drawee-backends/drawee-pipeline/src/main/java/com/facebook/drawee/backends/pipeline/Fresco.java
@@ -84,16 +84,16 @@ public class Fresco {
         clazz.getMethod("init", Context.class).invoke(null, context);
       } catch (ClassNotFoundException e) {
         // Failed to initialize SoLoader
-        initializeNativeLoaderWithSystemDelegate();
+        NativeLoader.initIfUninitialized(new SystemDelegate());
       } catch (IllegalAccessException e) {
         // Failed to initialize SoLoader
-        initializeNativeLoaderWithSystemDelegate();
+        NativeLoader.initIfUninitialized(new SystemDelegate());
       } catch (InvocationTargetException e) {
         // Failed to initialize SoLoader
-        initializeNativeLoaderWithSystemDelegate();
+        NativeLoader.initIfUninitialized(new SystemDelegate());
       } catch (NoSuchMethodException e) {
         // Failed to initialize SoLoader
-        initializeNativeLoaderWithSystemDelegate();
+        NativeLoader.initIfUninitialized(new SystemDelegate());
       } finally {
         if (FrescoSystrace.isTracing()) {
           FrescoSystrace.endSection();
@@ -110,14 +110,6 @@ public class Fresco {
     initializeDrawee(context, draweeConfig);
     if (FrescoSystrace.isTracing()) {
       FrescoSystrace.endSection();
-    }
-  }
-
-  private static void initializeNativeLoaderWithSystemDelegate() {
-    synchronized (NativeLoader.class) {
-      if (!NativeLoader.isInitialized()) {
-        NativeLoader.init(new SystemDelegate());
-      }
     }
   }
 


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [X] Explain the **motivation** for making this change.
- [X] Provide a **test plan** demonstrating that the code is solid.
- [X] Match the **code formatting** of the rest of the codebase.
- [X] Target the `master` branch

## Motivation (required)

Update to PR#2579 to make use of the new API method exposed by SoLoader 0.10.0. Using the new API means that the responsibility of ensuring the SoLoader NativeLoader initialisation checks and initialisation moves to SoLoader where it can be updated as appropriate and all SoLoader clients will benefit.

PR#2579 required other clients to be aware of the class we were synchronizing on, whereas with SoLoaders API that requirement no longer exists.

## Test Plan (required)

There are no functional changes in this PR, but there is a library update. Existing tests will ensure that the exposed behaviours of Fresco aren't changed.
