### PR TITLE
Fixed LocalVideoThumbnailProducer when retrieving video thumbnails

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -77,18 +77,22 @@ public class LocalVideoThumbnailProducer implements Producer<CloseableReference<
 
           @Override
           protected @Nullable CloseableReference<CloseableImage> getResult() throws Exception {
-            Bitmap thumbnailBitmap;
+            Bitmap thumbnailBitmap = null;
             String path;
             try {
               path = getLocalFilePath(imageRequest);
             } catch (IllegalArgumentException e) {
               path = null;
             }
-            thumbnailBitmap =
-                path != null
-                    ? ThumbnailUtils.createVideoThumbnail(path, calculateKind(imageRequest))
-                    : createThumbnailFromContentProvider(
+
+            if (path != null) {
+              thumbnailBitmap = ThumbnailUtils.createVideoThumbnail(path, calculateKind(imageRequest));
+            }
+
+            if (thumbnailBitmap == null) {
+                thumbnailBitmap = createThumbnailFromContentProvider(
                         mContentResolver, imageRequest.getSourceUri());
+            }
 
             if (thumbnailBitmap == null) {
               return null;


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch

## Motivation (required)
Fix issue where **fresco** fails to obtain video thumbnails in API 29.

What existing problem does the pull request solve?

**LocalVideoThumbnailProducer** has two flows to obtain video thumbnails. If it is able to obtain a media file path then it calls the Android SDK **ThumbnailUtils.createVideoThumbnail**, otherwise calls **createThumbnailFromContentProvider** with the media **Uri**.

**ThumbnailUtils.createVideoThumbnail** fails in Android 10, as such implementation uses the File API which in API 29 cannot be used to access public media, resulting in a null bitmap and warning log:  _java.io.IOException: Failed to create thumbnail_ 

Note that for package private media there are no issues, as the File API can still be used for such scenario. 
Also note that in API 30 the File API can be used again **but only** to access scoped storage folders: (DCIM, Music, etc.).

To solve the issue, when **ThumbnailUtils.createVideoThumbnail** fails, fallback to **createThumbnailFromContentProvider**, as such method uses the media Uri with the MediaMetadataRetriever, which works on all API levels.
The reason to go for a fallback instead of API branching, is because the File API (used by ThumbnailUtils), can still be used for private media.

The reason the bug is not seen with consistency in all devices, is because all depends on if the **MediaStore.DATA** field has been populated. For devices where the field is empty the bug doesn't happen, as the producer already falls back to use the Uri.
Consider that **MediaStore.DATA** [was deprecated in API 29](https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#DATA), and may or may not contain a file path or even not be accessible at all. So, its value should not be used anymore regardless if it has a valid path, as starting with API >=29 the File API cannot be used anymore for all device locations.

## Test Plan (required)

Prerequisites:
1) Device with API 29.
2) The file must not be local to the project, instead must be located in any public folder, such as DCIM.
2) Ensure that test video file has a valid File path stored in **MediaStore.DATA** field.

Test actions:
1) Use fresco to retrieve the test video file thumbnail.
2) A video thumbnail should be returned.


## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
