### PR TITLE
Publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         java-version: 1.8
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
+    - name: Install NDK 20, 21
+      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
     - name: Update gradle.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     - name: Update gradle.properties
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}" >> gradle.properties
     - name: Upload Android Archives
-      run: ./gradlew publish --no-daemon --no-parallel --info
-    - name: Release and close
-      run: ./gradlew closeAndReleaseRepository
+      run: ./gradlew publish --no-daemon --no-parallel --info --stacktrace
+    # - name: Release and close
+    #   run: ./gradlew closeAndReleaseRepository
     - name: Clean secrets
       if: always()
       run: rm /tmp/secring.gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,8 @@ jobs:
         java-version: 1.8
     - name: Setup Android SDK
       uses: android-actions/setup-android@v2
-    - name: Install NDK 20, 21
-      run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
-    - name: ls path
-      run: ls "/usr/local/lib/android/sdk/ndk-bundle"
-    - name: Update path
-      run: echo "/usr/local/lib/android/sdk/ndk-bundle" >> $GITHUB_PATH
+    - name: Register NDK
+      run: "echo 'ndk.path=/usr/local/lib/android/sdk/ndk-bundle' >> local.properties"
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
     - name: Update gradle.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
+    - name: Write GPG Sec Ring
+      run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
+    - name: Update gradle.properties
+      run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}" >> gradle.properties
+    - name: Upload Android Archives
+      run: ./gradlew publish --no-daemon --no-parallel --info
+    - name: Release and close
+      run: ./gradlew closeAndReleaseRepository
+    - name: Clean secrets
+      if: always()
+      run: rm /tmp/secring.gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
       uses: android-actions/setup-android@v2
     - name: Install NDK 20, 21
       run: echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "ndk;21.0.6113669" "ndk;20.0.5594570" --sdk_root=${ANDROID_SDK_ROOT}
+    - name: ls path
+      run: ls "/usr/local/lib/android/sdk/ndk-bundle"
+    - name: Update path
+      run: echo "/usr/local/lib/android/sdk/ndk-bundle" >> $GITHUB_PATH
     - name: Write GPG Sec Ring
       run: echo '${{ secrets.GPG_KEY_CONTENTS }}' | base64 -d > /tmp/secring.gpg
     - name: Update gradle.properties

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       run: echo -e "signing.secretKeyRingFile=/tmp/secring.gpg\nsigning.keyId=${{ secrets.SIGNING_KEY_ID }}\nsigning.password=${{ secrets.SIGNING_PASSWORD }}\nmavenCentralPassword=${{ secrets.SONATYPE_NEXUS_PASSWORD }}\nmavenCentralUsername=${{ secrets.SONATYPE_NEXUS_USERNAME }}" >> gradle.properties
     - name: Upload Android Archives
       run: ./gradlew publish --no-daemon --no-parallel --info --stacktrace
-    # - name: Release and close
-    #   run: ./gradlew closeAndReleaseRepository
+    - name: Release and close
+      run: ./gradlew closeAndReleaseRepository
     - name: Clean secrets
       if: always()
       run: rm /tmp/secring.gpg


### PR DESCRIPTION
Depends on #2606.

Summary:
Sets up an automated workflow for running the full Maven release flow (sans internal javadoc release). Only requires creating a new release on the GitHub UI, or manually triggering the workflow.

The secrets used are already set up in the project.

Test Plan:
https://github.com/passy/fresco/runs/2658576914?check_suite_focus=true

Ran all the way until signing gets involved, which was expected to fail.