### PR TITLE
change imageId in AnimatedImageResult from the class hash to decodeHa…

### DIFF
--- a/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
+++ b/animated-base/src/main/java/com/facebook/fresco/animation/factory/AnimatedFactoryV2Impl.java
@@ -134,7 +134,7 @@ public class AnimatedFactoryV2Impl implements AnimatedFactory {
           }
         };
 
-    final Supplier<Boolean> useDeepEquals = Suppliers.BOOLEAN_FALSE;
+    final Supplier<Boolean> useDeepEquals = Suppliers.BOOLEAN_TRUE;
 
     return new ExperimentalBitmapAnimationDrawableFactory(
         getAnimatedDrawableBackendProvider(),

--- a/animated-base/src/main/java/com/facebook/fresco/animation/factory/ExperimentalBitmapAnimationDrawableFactory.java
+++ b/animated-base/src/main/java/com/facebook/fresco/animation/factory/ExperimentalBitmapAnimationDrawableFactory.java
@@ -163,7 +163,7 @@ public class ExperimentalBitmapAnimationDrawableFactory implements DrawableFacto
   private AnimatedFrameCache createAnimatedFrameCache(
       final AnimatedImageResult animatedImageResult) {
     return new AnimatedFrameCache(
-        new AnimationFrameCacheKey(animatedImageResult.hashCode(), mUseDeepEqualsForCacheKey.get()),
+        new AnimationFrameCacheKey(animatedImageResult.getDecodeHash(), mUseDeepEqualsForCacheKey.get()),
         mBackingCache);
   }
 }

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResult.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResult.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class AnimatedImageResult {
 
+  private int mDecodeHash;
   private final AnimatedImage mImage;
   private final int mFrameForPreview;
   private @Nullable CloseableReference<Bitmap> mPreviewBitmap;
@@ -34,11 +35,16 @@ public class AnimatedImageResult {
     mPreviewBitmap = builder.getPreviewBitmap();
     mDecodedFrames = builder.getDecodedFrames();
     mBitmapTransformation = builder.getBitmapTransformation();
+    mDecodeHash = builder.getDecodeHash();
   }
 
   private AnimatedImageResult(AnimatedImage image) {
     mImage = Preconditions.checkNotNull(image);
     mFrameForPreview = 0;
+  }
+
+  public int getDecodeHash(){
+    return mDecodeHash == 0 ? hashCode() : mDecodeHash;
   }
 
   /**

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResultBuilder.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/base/AnimatedImageResultBuilder.java
@@ -18,6 +18,7 @@ import javax.annotation.Nullable;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class AnimatedImageResultBuilder {
 
+  private int mDecodeHash;
   private final AnimatedImage mImage;
   private @Nullable CloseableReference<Bitmap> mPreviewBitmap;
   private @Nullable List<CloseableReference<Bitmap>> mDecodedFrames;
@@ -26,6 +27,16 @@ public class AnimatedImageResultBuilder {
 
   AnimatedImageResultBuilder(AnimatedImage image) {
     mImage = image;
+  }
+
+
+  public int getDecodeHash() {
+    return mDecodeHash;
+  }
+
+  public AnimatedImageResultBuilder setDecodeHash(int decodeHash) {
+    this.mDecodeHash = decodeHash;
+    return this;
   }
 
   /**

--- a/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
+++ b/animated-base/src/main/java/com/facebook/imagepipeline/animated/factory/AnimatedImageFactoryImpl.java
@@ -90,7 +90,7 @@ public class AnimatedImageFactoryImpl implements AnimatedImageFactory {
             sGifAnimatedImageDecoder.decodeFromNativeMemory(
                 input.getNativePtr(), input.size(), options);
       }
-      return getCloseableImage(options, gifImage, bitmapConfig);
+      return getCloseableImage(bytesRef.getValueHash(), options, gifImage, bitmapConfig);
     } finally {
       CloseableReference.closeSafely(bytesRef);
     }
@@ -130,8 +130,12 @@ public class AnimatedImageFactoryImpl implements AnimatedImageFactory {
     }
   }
 
+  private CloseableImage getCloseableImage(ImageDecodeOptions options, AnimatedImage image, Bitmap.Config bitmapConfig) {
+    return getCloseableImage(0, options, image, bitmapConfig);
+  }
+
   private CloseableImage getCloseableImage(
-      ImageDecodeOptions options, AnimatedImage image, Bitmap.Config bitmapConfig) {
+          int valueHash, ImageDecodeOptions options, AnimatedImage image, Bitmap.Config bitmapConfig) {
     List<CloseableReference<Bitmap>> decodedFrames = null;
     CloseableReference<Bitmap> previewBitmap = null;
     try {
@@ -157,6 +161,7 @@ public class AnimatedImageFactoryImpl implements AnimatedImageFactory {
               .setFrameForPreview(frameForPreview)
               .setDecodedFrames(decodedFrames)
               .setBitmapTransformation(options.bitmapTransformation)
+              .setDecodeHash(valueHash + options.hashCode())
               .build();
       return new CloseableAnimatedImage(animatedImageResult);
     } finally {


### PR DESCRIPTION
I create a issue a few days ago, #2605, I'm kind of dying to know if this is a bug? And if this is, is my way of fixing it appropriate?


Test Plan
Load the same GIF multiple times, and :
1. Look at the Android profiler to see if the memory keeps increasingl
2. Debug if the count of entries in the cache pool keeps increasing.
Like the image in the #2605 shows.
