### PR TITLE
duplicate value for resource

### DIFF
--- a/drawee/src/main/res/values/attrs.xml
+++ b/drawee/src/main/res/values/attrs.xml
@@ -186,9 +186,6 @@
     <!-- Progress bar Auto Rotate interval in milliseconds -->
     <attr name="progressBarAutoRotateInterval" />
 
-    <!-- Scale type of the actual image. -->
-    <attr name="actualImageScaleType" />
-
     <!-- A drawable or color to be used as a background. -->
     <attr name="backgroundImage" />
 


### PR DESCRIPTION
## Motivation (required)

duplicate value for 'attr/actualImageScaleType' in line 87 and 190.

- May cause runtime errors

> AAPT: error: duplicate value for resource 'attr/actualImageScaleType' with config ''.

## Test Plan (required)

Looking for the necessary path.
