### PR TITLE
fix load gallery video content uri failed

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -142,6 +142,10 @@ public class LocalVideoThumbnailProducer implements Producer<CloseableReference<
     if (UriUtil.isLocalFileUri(uri)) {
       return imageRequest.getSourceFile().getPath();
     } else if (UriUtil.isLocalContentUri(uri)) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !Environment.isExternalStorageLegacy()){
+        return null;
+      }
+      
       String selection = null;
       String[] selectionArgs = null;
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT


### PR DESCRIPTION
if not set `android:requestLegacyExternalStorage="true"` in Androidmanifest.xml,
there are no permission to access video path on Android Q.
we need use createThumbnailFromContentProvider() to get video thumbnail
