### PR TITLE
fix load gallery video content uri failed

### DIFF
--- a/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
+++ b/imagepipeline/src/main/java/com/facebook/imagepipeline/producers/LocalVideoThumbnailProducer.java
@@ -14,6 +14,7 @@ import android.media.MediaMetadataRetriever;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Environment;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
@@ -142,6 +143,9 @@ public class LocalVideoThumbnailProducer implements Producer<CloseableReference<
     if (UriUtil.isLocalFileUri(uri)) {
       return imageRequest.getSourceFile().getPath();
     } else if (UriUtil.isLocalContentUri(uri)) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !Environment.isExternalStorageLegacy()) {
+        return null;
+      }
       String selection = null;
       String[] selectionArgs = null;
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT


### PR DESCRIPTION
if not set android:requestLegacyExternalStorage="true" in Androidmanifest.xml,
there are no permission to access video path on Android Q.
we need use createThumbnailFromContentProvider() to get video thumbnail
