### PR TITLE
webp doesRenderSupportScaling should return false

### DIFF
--- a/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
+++ b/animated-webp/src/main/java/com/facebook/animated/webp/WebPImage.java
@@ -165,7 +165,7 @@ public class WebPImage implements AnimatedImage, AnimatedImageDecoder {
 
   @Override
   public boolean doesRenderSupportScaling() {
-    return true;
+    return false;
   }
 
   @Override


### PR DESCRIPTION

doesRenderSupportScaling() will be used on 
```AnimatedDrawableBackendImpl.java
  @Override
  public void renderFrame(int frameNumber, Canvas canvas) {
    AnimatedImageFrame frame = mAnimatedImage.getFrame(frameNumber);
    try {
      if (frame.getWidth() <= 0 || frame.getHeight() <= 0) {
        return; // Frame not visible -> skipping
      }

      if (mAnimatedImage.doesRenderSupportScaling()) {
        renderImageSupportsScaling(canvas, frame);
      } else {
        renderImageDoesNotSupportScaling(canvas, frame);
      }
    } finally {
      frame.dispose();
    }
  }
```
if doesRenderSupportScaling() reruen true, will step into renderImageSupportsScaling()
```
  private void renderImageSupportsScaling(Canvas canvas, AnimatedImageFrame frame) {
    double xScale = (double) mRenderedBounds.width() / (double) mAnimatedImage.getWidth();
    double yScale = (double) mRenderedBounds.height() / (double) mAnimatedImage.getHeight();

    int frameWidth = (int) Math.round(frame.getWidth() * xScale);
    int frameHeight = (int) Math.round(frame.getHeight() * yScale);
    int xOffset = (int) (frame.getXOffset() * xScale);
    int yOffset = (int) (frame.getYOffset() * yScale);

    synchronized (this) {
      int renderedWidth = mRenderedBounds.width();
      int renderedHeight = mRenderedBounds.height();
      // Update the temp bitmap to be >= rendered dimensions
      prepareTempBitmapForThisSize(renderedWidth, renderedHeight);
      if (mTempBitmap != null) {
        frame.renderFrame(frameWidth, frameHeight, mTempBitmap);
      }
      // Temporary bitmap can be bigger than frame, so we should draw only rendered area of bitmap
      mRenderSrcRect.set(0, 0, renderedWidth, renderedHeight);
      mRenderDstRect.set(xOffset, yOffset, xOffset + renderedWidth, yOffset + renderedHeight);

      if (mTempBitmap != null) {
        canvas.drawBitmap(mTempBitmap, mRenderSrcRect, mRenderDstRect, null);
      }
    }
  }
```
and  mRenderedBounds is set on 
```
  private static Rect getBoundsToUse(AnimatedImage image, @Nullable Rect targetBounds) {
    if (targetBounds == null) {
      return new Rect(0, 0, image.getWidth(), image.getHeight());
    }
    return new Rect(
        0,
        0,
        Math.min(targetBounds.width(), image.getWidth()),
        Math.min(targetBounds.height(), image.getHeight()));
  }
```
this used Math.min()
if image is 800*200 and imageview is 600 * 600

on 
```
   double xScale = (double) mRenderedBounds.width() / (double) mAnimatedImage.getWidth();
    double yScale = (double) mRenderedBounds.height() / (double) mAnimatedImage.getHeight();
```
xScale = 600/600
yScale = 200/600

when ImageView used fitXY,image will 
<img width="245" alt="image" src="https://github.com/facebook/fresco/assets/21054581/0082faac-2852-4261-9c04-f24c1f234241">
but gif is ok 
<img width="250" alt="image" src="https://github.com/facebook/fresco/assets/21054581/a9c79100-6f3e-4918-bec2-532c1e0dd831">

imgurl : https://img30.360buyimg.com/jdg/jfs/t1/149870/35/35283/484582/646d86adF018933f5/84a130d59b9de2df.gif.webp