### PR TITLE
Bump Flipper Min SDK to 21

### DIFF
--- a/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
+++ b/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
@@ -10,7 +10,7 @@ object FrescoConfig {
 
   const val compileSdkVersion = 34
   const val minSdkVersion = 21
-  const val flipperPluginMinSdkVersion = 16
+  const val flipperPluginMinSdkVersion = 21
   const val vitoLithoMinSdkVersion = 16
   const val samplesMinSdkVersion = 21
   const val targetSdkVersion = 34

--- a/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
+++ b/buildSrc/src/main/java/com/facebook/fresco/buildsrc/FrescoConfig.kt
@@ -11,7 +11,7 @@ object FrescoConfig {
   const val compileSdkVersion = 34
   const val minSdkVersion = 21
   const val flipperPluginMinSdkVersion = 21
-  const val vitoLithoMinSdkVersion = 16
+  const val vitoLithoMinSdkVersion = 21
   const val samplesMinSdkVersion = 21
   const val targetSdkVersion = 34
 }


### PR DESCRIPTION
Getting this on CircleCI:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tools:flipper-fresco-plugin:processDebugAndroidTestManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [:tools:flipper] /home/circleci/project/tools/flipper/build/intermediates/merged_manifest/debug/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.fresco.flipper" to force usage (may lead to runtime failures)
```