### PR TITLE
[maven] Update release setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ buildscript {
         classpath GradleDeps.Android.gradlePlugin
         classpath GradleDeps.Kotlin.gradlePlugin
 
-        classpath GradleDeps.Publishing.gradleMavenPublishPlugin
         classpath GradleDeps.Kotlin.gradlePlugin
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -31,6 +30,7 @@ buildscript {
 
 plugins {
     id "de.undercouch.download" version "5.3.1"
+    id "com.vanniktech.maven.publish" version "0.25.3"
 }
 
 project.ext {
@@ -49,6 +49,11 @@ subprojects {
     tasks.withType(Javadoc).all {
         enabled = false
     }
+
+    tasks.withType(com.android.build.gradle.tasks.JavaDocGenerationTask).all {
+        enabled = false
+    }
+
 
     if (System.getenv("SANDCASTLE") == "1") {
         tasks.withType(Test).all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,3 +43,6 @@ LIBPNG_VERSION=1.6.37
 GIFLIB_VERSION=5.2.1
 # When updating this also change the version in static-webp/src/main/jni/static-webp/Android.mk
 LIBWEBP_VERSION=1.0.0
+
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
[maven] Update release setup

Summary:
These changes were necessary to unbreak the build. Specifically

```
Task 'closeAndReleaseRepository' not found in root project 'fresco'.
```

as seen in https://github.com/facebook/fresco/actions/runs/6225167194/job/16896133954

Test Plan:
Locally ran

```
./gradlew publish
./gradlew closeAndReleaseRepository
```
