### PR TITLE
Fix missing native dependencies on packaged artifacts

### DIFF
--- a/animated-gif/build.gradle
+++ b/animated-gif/build.gradle
@@ -60,6 +60,7 @@ android {
         }
     }
     ndkLibs.each { lib -> makeNdkTasks lib[0], lib[1] }
+    preBuild.dependsOn("ndk_build_gifimage")
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/imagepipeline-native/build.gradle
+++ b/imagepipeline-native/build.gradle
@@ -71,6 +71,11 @@ android {
         }
     }
     ndkLibs.each { lib -> makeNdkTasks lib[0], lib[1] }
+    preBuild.dependsOn(
+        "ndk_build_bitmaps",
+        "ndk_build_imagepipeline",
+        "ndk_build_memchunk"
+    )
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/native-filters/build.gradle
+++ b/native-filters/build.gradle
@@ -75,6 +75,10 @@ android {
         abortOnError false
     }
     ndkLibs.each { lib -> makeNdkTasks lib[0], lib[1] }
+    preBuild.dependsOn(
+        "ndk_build_filters",
+        "ndk_build_native-filters"
+    )
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/native-imagetranscoder/build.gradle
+++ b/native-imagetranscoder/build.gradle
@@ -48,7 +48,6 @@ task fetchNativeDeps(dependsOn: [copyLibjpeg]) {
 }
 
 android {
-
     def ndkLibs = [
             ['native-imagetranscoder', [copyLibjpeg]]]
 
@@ -76,6 +75,10 @@ android {
         abortOnError false
     }
     ndkLibs.each { lib -> makeNdkTasks lib[0], lib[1] }
+    preBuild.dependsOn(
+        "ndk_build_native-imagetranscoder",
+        "copyLibjpeg"
+    )
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/static-webp/build.gradle
+++ b/static-webp/build.gradle
@@ -57,6 +57,12 @@ android {
         abortOnError false
     }
     ndkLibs.each { lib -> makeNdkTasks lib[0], lib[1] }
+    preBuild.dependsOn(
+        "ndk_build_static-webp",
+        "copyLibjpeg",
+        "copyLibpng",
+        "copyLibwebp"
+    )
 }
 
 apply plugin: "com.vanniktech.maven.publish"


### PR DESCRIPTION
## Motivation (required)

Latest versions of Fresco have missing .so files due to a race condition on Gradle tasks.
I'm imposing a task dependencies on `ndk_build_*` steps and `preBuild` steps to prevent this.

Fixes #2722
Fixes #2747

## Test Plan (required)

I've tested this against `./gradlew publishToMavenLocal` upon clean build.
Here the output:
```
$ unzip -l ~/.m2/repository/com/facebook/fresco/nativeimagetranscoder/3.1.1/nativeimagetranscoder-3.1.1.aar
Archive:  /Users/ncor/.m2/repository/com/facebook/fresco/nativeimagetranscoder/3.1.1/nativeimagetranscoder-3.1.1.aar
  Length      Date    Time    Name
---------  ---------- -----   ----
     7297  02-01-1980 00:00   R.txt
      216  02-01-1980 00:00   AndroidManifest.xml
     6034  02-01-1980 00:00   classes.jar
      121  02-01-1980 00:00   META-INF/com/android/build/gradle/aar-metadata.properties
        0  02-01-1980 00:00   jni/
        0  02-01-1980 00:00   jni/arm64-v8a/
   475392  02-01-1980 00:00   jni/arm64-v8a/libnative-imagetranscoder.so
        0  02-01-1980 00:00   jni/armeabi-v7a/
   271736  02-01-1980 00:00   jni/armeabi-v7a/libnative-imagetranscoder.so
        0  02-01-1980 00:00   jni/x86/
   557648  02-01-1980 00:00   jni/x86/libnative-imagetranscoder.so
        0  02-01-1980 00:00   jni/x86_64/
   621000  02-01-1980 00:00   jni/x86_64/libnative-imagetranscoder.so
---------                     -------
  1939444                     13 files
```