### PR TITLE
Convert the CircleCI workflow to a GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: facebook/fresco/build
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: nttld/setup-ndk@v1
+      with:
+        ndk-version: r25c
+    - name: Install JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: '18'
+        distribution: 'temurin'
+        cache: gradle
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: Run Tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 29
+        script: ./gradlew test assembleDebug -PdisablePreDex
+    - name: Copy Results
+      run: |
+        mkdir -p /home/circleci/test-results/junit
+        find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} /home/circleci/test-results/junit \;
+    - uses: actions/upload-artifact@v4.0.0
+      with:
+        path: "/home/circleci/test-results"


### PR DESCRIPTION
## Summary

This pull request converts the CircleCI workflows to GitHub actions workflows. [Github Actions Importer](https://github.com/github/gh-actions-importer) was used to convert the workflows initially, then I edited them manually to correct errors in translation.

**Issues**

1. _facebook/fresco/build -> Run Tests_

```
Execution failed for task ':animated-base:testDebugUnitTest'.
```

<details>
<summary style="list-style-type: none;">Full Error</summary>
<pre>
com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenCloseableStaticBitmapNull_thenReturnNull FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenBitmapReferenceInvalid_thenReturnReference FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenBitmapRecycled_thenReturnReference FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenImageReferenceInvalid_thenReturnNull FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenInputNull_thenReturnNull FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40

com.facebook.fresco.animation.bitmap.cache.FrescoFrameCacheTest > testExtractAndClose_whenCloseableStaticBitmapClosed_thenReturnNull FAILED
    org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
        Caused by: org.mockito.exceptions.base.MockitoException at FrescoFrameCacheTest.java:40
            Caused by: java.lang.IllegalStateException at FrescoFrameCacheTest.java:40
                Caused by: java.lang.IllegalArgumentException at FrescoFrameCacheTest.java:40
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

com.facebook.fresco.animation.bitmap.wrapper.AnimatedDrawableBackendFrameRendererTest > testRenderFrameUnsuccessful FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:104
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:104
            Caused by: java.lang.IllegalStateException at AnimatedDrawableBackendFrameRendererTest.java:104
                Caused by: java.lang.IllegalArgumentException at AnimatedDrawableBackendFrameRendererTest.java:104

com.facebook.fresco.animation.bitmap.wrapper.AnimatedDrawableBackendFrameRendererTest > testSetBounds FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:52
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:52
            Caused by: java.lang.IllegalStateException at AnimatedDrawableBackendFrameRendererTest.java:52
                Caused by: java.lang.IllegalArgumentException at AnimatedDrawableBackendFrameRendererTest.java:52

com.facebook.fresco.animation.bitmap.wrapper.AnimatedDrawableBackendFrameRendererTest > testRenderFrame FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:104
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedDrawableBackendFrameRendererTest.java:104
            Caused by: java.lang.IllegalStateException at AnimatedDrawableBackendFrameRendererTest.java:104
                Caused by: java.lang.IllegalArgumentException at AnimatedDrawableBackendFrameRendererTest.java:104

com.facebook.imagepipeline.animated.impl.AnimatedDrawableBackendImplTest > testOffsets FAILED
    java.lang.RuntimeException at AbstractClassloaderExecutor.java:108
        Caused by: java.lang.reflect.InvocationTargetException at DirectConstructorHandleAccessor.java:79
            Caused by: java.lang.ExceptionInInitializerError at XStream.java:989
                Caused by: java.lang.reflect.InaccessibleObjectException at AccessibleObject.java:354

com.facebook.imagepipeline.animated.impl.AnimatedDrawableBackendImplTest > testNoUpscaling FAILED
    java.lang.RuntimeException at AbstractClassloaderExecutor.java:108
        Caused by: java.lang.reflect.InvocationTargetException at DirectConstructorHandleAccessor.java:79
            Caused by: java.lang.NoClassDefFoundError at XStream.java:989
                Caused by: java.lang.ExceptionInInitializerError at AccessibleObject.java:354

com.facebook.imagepipeline.animated.impl.AnimatedDrawableBackendImplTest > testNarrow FAILED
    java.lang.RuntimeException at AbstractClassloaderExecutor.java:108
        Caused by: java.lang.reflect.InvocationTargetException at DirectConstructorHandleAccessor.java:79
            Caused by: java.lang.NoClassDefFoundError at XStream.java:989
                Caused by: java.lang.ExceptionInInitializerError at AccessibleObject.java:354

com.facebook.imagepipeline.animated.impl.AnimatedDrawableBackendImplTest > testSimple FAILED
    java.lang.RuntimeException at AbstractClassloaderExecutor.java:108
        Caused by: java.lang.reflect.InvocationTargetException at DirectConstructorHandleAccessor.java:79
            Caused by: java.lang.NoClassDefFoundError at XStream.java:989
                Caused by: java.lang.ExceptionInInitializerError at AccessibleObject.java:354

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testContainsFullReuseFlowWithMultipleItems FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testBasic FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testReuse FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testCantReuseIfNotClosed FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testStillThereIfClosed FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testMultipleFrames FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testContains FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testReplace FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.animated.impl.AnimatedFrameCacheTest > testContainsWhenReused FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedFrameCacheTest.java:53
            Caused by: java.lang.IllegalStateException at AnimatedFrameCacheTest.java:53
                Caused by: java.lang.IllegalArgumentException at AnimatedFrameCacheTest.java:53

com.facebook.imagepipeline.producers.AnimatedRepeatedPostprocessorProducerTest > testNonStaticBitmapIsPassedOn FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedRepeatedPostprocessorProducerTest.java:76
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedRepeatedPostprocessorProducerTest.java:76
            Caused by: java.lang.IllegalStateException at AnimatedRepeatedPostprocessorProducerTest.java:76
                Caused by: java.lang.IllegalArgumentException at AnimatedRepeatedPostprocessorProducerTest.java:76

com.facebook.imagepipeline.producers.AnimatedSingleUsePostprocessorProducerTest > testNonStaticBitmapIsPassedOn FAILED
    org.mockito.exceptions.base.MockitoException at AnimatedSingleUsePostprocessorProducerTest.java:69
        Caused by: org.mockito.exceptions.base.MockitoException at AnimatedSingleUsePostprocessorProducerTest.java:69
            Caused by: java.lang.IllegalStateException at AnimatedSingleUsePostprocessorProducerTest.java:69
                Caused by: java.lang.IllegalArgumentException at AnimatedSingleUsePostprocessorProducerTest.java:69

35 tests completed, 25 failed

> Task :animated-base:testDebugUnitTest FAILED
454 actionable tasks: 454 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':animated-base:testDebugUnitTest'.
</pre>
</details>

## How did you test this change?

I tested these changes in a [forked repo](https://github.com/robandpdx-org/fresco/actions/runs/8024468495).

https://fburl.com/workplace/f6mz6tmw