### PR TITLE
Remove deprecated dexOptions feature of Gradle

### DIFF
--- a/samples/showcase/build.gradle
+++ b/samples/showcase/build.gradle
@@ -26,11 +26,6 @@ android {
 
     namespace "com.facebook.fresco.samples.showcase"
 
-    dexOptions {
-        maxProcessCount 2
-        javaMaxHeapSize "1g"
-    }
-
     defaultConfig {
         applicationId "com.facebook.fresco.samples.showcase"
         minSdkVersion FrescoConfig.samplesMinSdkVersion


### PR DESCRIPTION
Reviewed By: kartavya-ramnani

Differential Revision: D60337703
