### PR TITLE
Fixed svg example

### DIFF
--- a/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.kt
+++ b/samples/showcase/src/main/java/com/facebook/fresco/samples/showcase/ShowcaseApplication.kt
@@ -23,6 +23,7 @@ import com.facebook.flipper.plugins.fresco.FrescoFlipperPlugin
 import com.facebook.flipper.plugins.fresco.FrescoFlipperRequestListener
 import com.facebook.flipper.plugins.inspector.DescriptorMapping
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.fresco.samples.showcase.imageformat.svg.SvgDecoderExample
 import com.facebook.fresco.samples.showcase.misc.DebugOverlaySupplierSingleton
 import com.facebook.fresco.samples.showcase.misc.ImageUriProvider
 import com.facebook.fresco.samples.showcase.misc.LogcatRequestListener2
@@ -164,6 +165,12 @@ class ShowcaseApplication : Application() {
       resources: Resources,
       vitoConfig: FrescoVitoConfig = DefaultFrescoVitoConfig(),
   ) {
+      val externalImageOptionsDrawableFactories = if (CustomImageFormatConfigurator.isSvgEnabled(this)) {
+          listOf(SvgDecoderExample.SvgDrawableFactory())
+      } else {
+          emptyList()
+      }
+
     if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean(KEY_VITO_KOTLIN, false)) {
       FrescoVito.initialize(
           KFrescoVitoProvider(
@@ -177,13 +184,18 @@ class ShowcaseApplication : Application() {
                   .executorSupplier
                   .forLightweightBackgroundTasks(),
               NoOpCallerContextVerifier,
-              DebugOverlayHandler(DebugOverlaySupplierSingleton.getInstance(applicationContext))))
+              DebugOverlayHandler(DebugOverlaySupplierSingleton.getInstance(applicationContext)),
+              externalImageOptionsDrawableFactories,
+          )
+      )
     } else {
       FrescoVito.initialize(
           vitoConfig = vitoConfig,
           debugOverlayEnabledSupplier =
               DebugOverlaySupplierSingleton.getInstance(applicationContext),
-          vitoImagePerfListener = imageTracker)
+          vitoImagePerfListener = imageTracker,
+          externalImageOptionsDrawableFactories = externalImageOptionsDrawableFactories
+      )
     }
   }
 

--- a/vito/init/src/main/java/com/facebook/fresco/vito/init/FrescoVito.kt
+++ b/vito/init/src/main/java/com/facebook/fresco/vito/init/FrescoVito.kt
@@ -29,6 +29,7 @@ import com.facebook.fresco.vito.provider.impl.NoOpCallerContextVerifier
 import com.facebook.fresco.vito.provider.setup.FrescoVitoSetup
 import com.facebook.imagepipeline.core.ImagePipeline
 import com.facebook.imagepipeline.core.ImagePipelineFactory
+import com.facebook.imagepipeline.drawable.DrawableFactory
 import java.util.concurrent.Executor
 
 class FrescoVito {
@@ -60,6 +61,7 @@ class FrescoVito {
         imagePerfListenerSupplier: Supplier<ImagePerfLoggingListener>? = null,
         showExtendedDebugOverlayInformation: Boolean = true,
         showExtendedImageSourceExtraInformation: Boolean = false,
+        externalImageOptionsDrawableFactories: List<DrawableFactory> = emptyList(),
     ) {
       if (isInitialized) {
         return
@@ -84,7 +86,10 @@ class FrescoVito {
                     showExtendedImageSourceExtraInformation,
                     it)
               } ?: NoOpDebugOverlayFactory2(),
-              imagePerfListenerSupplier))
+              imagePerfListenerSupplier,
+              externalImageOptionsDrawableFactories,
+          ),
+      )
     }
 
     /**

--- a/vito/provider/src/main/java/com/facebook/fresco/vito/provider/impl/kotlin/KFrescoVitoProvider.kt
+++ b/vito/provider/src/main/java/com/facebook/fresco/vito/provider/impl/kotlin/KFrescoVitoProvider.kt
@@ -24,6 +24,7 @@ import com.facebook.fresco.vito.provider.impl.NoOpCallerContextVerifier
 import com.facebook.fresco.vito.provider.setup.FrescoVitoSetup
 import com.facebook.imagepipeline.core.ImagePipeline
 import com.facebook.imagepipeline.core.ImagePipelineFactory
+import com.facebook.imagepipeline.drawable.DrawableFactory
 import java.util.concurrent.Executor
 
 class KFrescoVitoProvider(
@@ -33,7 +34,8 @@ class KFrescoVitoProvider(
     private val uiThreadExecutor: Executor,
     private val lightweightBackgroundExecutor: Executor,
     private val callerContextVerifier: CallerContextVerifier = NoOpCallerContextVerifier,
-    private val debugOverlayHandler: DebugOverlayHandler? = null
+    private val debugOverlayHandler: DebugOverlayHandler? = null,
+    private val externalImageOptionsDrawableFactories: List<DrawableFactory> = emptyList()
 ) : FrescoVitoSetup {
 
   private val _imagePipeline: VitoImagePipeline by lazy {
@@ -71,7 +73,8 @@ class KFrescoVitoProvider(
         ImagePipelineFactory.getInstance()
             .getXmlDrawableFactory()
             ?.let(DrawableFactoryWrapper::wrap)
-    val factories = listOfNotNull(animatedDrawableFactory, xmlFactory)
+    val factories = listOfNotNull(animatedDrawableFactory, xmlFactory) +
+            externalImageOptionsDrawableFactories.map(DrawableFactoryWrapper::wrap)
     return when (factories.size) {
       0 -> null
       1 -> factories[0]


### PR DESCRIPTION
## Motivation 

Fixes broken example of loading svg using fresco. Fixes https://github.com/facebook/fresco/issues/2820

## Test Plan 

### Vito's java implementation

1. Launch showcase project
2. Open svg screen using sidebar menu
3. Enable toggle "Svg support enable"
4. Press "kill now" in an appeared dialog
5. Open showcase application
6. Make sure fresco's svg logo is displayed
<img src="https://github.com/user-attachments/assets/93ad5036-4808-4d2e-8576-72f672494900" height="300" alt="svg shown using vito java impl"/>

### Vito's kotlin implementation

1. Launch showcase project
2. Open settings screen using sidebar menu
3. Enable vito -> "Use kotlin implemention" setting
4. Open svg screen using sidebar menu
5. Enable toggle "Svg support enable"
6. Press "kill now" in an appeared dialog
7. Open showcase application
8. Make sure fresco's svg logo is displayed

<img src="https://github.com/user-attachments/assets/cebfd4d8-c003-41cd-bfe5-b33acdf61574" height="300" alt="svg shown using vito kotlin impl"/>

