### PR TITLE
Fixed AnimationCoordinator.onRenderFrame by `containsKey`

### DIFF
--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/preparation/ondemandanimation/AnimationCoordinator.kt
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/bitmap/preparation/ondemandanimation/AnimationCoordinator.kt
@@ -98,7 +98,7 @@ object AnimationCoordinator {
    * the animation performance based on this data.
    */
   fun onRenderFrame(animation: DynamicRenderingFps, frameResult: FrameResult) {
-    if (!runningAnimations.contains(animation)) {
+    if (!runningAnimations.containsKey(animation)) {
       val fps = animation.animationFps
       val fpsStep = fps.times(FPS_STEP_PERCENTAGE).toInt()
 


### PR DESCRIPTION
## Motivation (required)
Class `AnimationCoordinator` contains bug in `onRenderFrame`.

Class ConcurrentHashMap method `contains` checks `containsValue`, not key.

Text from documentation:
_Tests if some key maps into the specified value in this table._

https://developer.android.com/reference/java/util/concurrent/ConcurrentHashMap#contains(java.lang.Object)

