### PR TITLE
Add synchronized to onIntermediateImageFailed 

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/controller/ForwardingControllerListener.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/ForwardingControllerListener.java
@@ -115,7 +115,7 @@ public class ForwardingControllerListener<INFO>
   }
 
   @Override
-  public void onIntermediateImageFailed(String id, Throwable throwable) {
+  public synchronized void onIntermediateImageFailed(String id, Throwable throwable) {
     final int numberOfListeners = mListeners.size();
     for (int i = 0; i < numberOfListeners; ++i) {
       try {


### PR DESCRIPTION
## Motivation

This pull request synchronizes the onIntermediateImageFailed method in ForwardingControllerListener.
The method iterates over a shared list of listeners (mListeners), and without synchronization, it may result in concurrent modification exceptions or inconsistent behavior if accessed from multiple threads simultaneously.
Other similar methods like onFinalImageSet and onFailure are already synchronized, so this change brings consistency and improves thread safety.

## Test Plan

Ran ./gradlew build
