### PR TITLE
fix: get image info before creating drawable to avoid IllegalStateException

### DIFF
--- a/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
+++ b/drawee/src/main/java/com/facebook/drawee/controller/AbstractDraweeController.java
@@ -647,7 +647,9 @@ public abstract class AbstractDraweeController<T, INFO>
           isFinished ? Event.ON_DATASOURCE_RESULT : Event.ON_DATASOURCE_RESULT_INT);
       // create drawable
       Drawable drawable;
+      INFO info;
       try {
+        info = getImageInfo(image);
         drawable = createDrawable(image);
       } catch (Exception exception) {
         logMessageAndImage("drawable_failed @ onNewResult", image);
@@ -665,11 +667,11 @@ public abstract class AbstractDraweeController<T, INFO>
           logMessageAndImage("set_final_result @ onNewResult", image);
           mDataSource = null;
           getSettableDraweeHierarchy().setImage(drawable, 1f, wasImmediate);
-          reportSuccess(id, image, dataSource);
+          reportSuccess(id, info, dataSource);
         } else if (deliverTempResult) {
           logMessageAndImage("set_temporary_result @ onNewResult", image);
           getSettableDraweeHierarchy().setImage(drawable, 1f, wasImmediate);
-          reportSuccess(id, image, dataSource);
+          reportSuccess(id, info, dataSource);
           // IMPORTANT: do not execute any instance-specific code after this point
         } else {
           logMessageAndImage("set_intermediate_result @ onNewResult", image);
@@ -846,8 +848,7 @@ public abstract class AbstractDraweeController<T, INFO>
     getControllerListener2().onIntermediateImageFailed(mId);
   }
 
-  private void reportSuccess(String id, @Nullable T image, @Nullable DataSource<T> dataSource) {
-    INFO info = getImageInfo(image);
+  private void reportSuccess(String id, @Nullable INFO info, @Nullable DataSource<T> dataSource) {
     getControllerListener().onFinalImageSet(id, info, getAnimatable());
     getControllerListener2().onFinalImageSet(id, info, obtainExtras(dataSource, info, null));
   }


### PR DESCRIPTION
## Motivation

This PR aims to mitigate crash caused by `IllegalStateException` thrown due to closable image reference being already closed when getting the image info.
The crash is reported as #2826. On my end with version 3.6.0 I get following stack trace
```
java.lang.IllegalStateException: null
    at com.facebook.common.internal.Preconditions.checkState(Preconditions.java:162)
    at com.facebook.drawee.backends.pipeline.PipelineDraweeController.getImageInfo(PipelineDraweeController.java:366)
    at com.facebook.drawee.backends.pipeline.PipelineDraweeController.getImageInfo(PipelineDraweeController.java:64)
    at com.facebook.drawee.controller.AbstractDraweeController.reportSuccess(AbstractDraweeController.java:849)
    at com.facebook.drawee.controller.AbstractDraweeController.onNewResultInternal(AbstractDraweeController.java:667)
    at com.facebook.drawee.controller.AbstractDraweeController.-$$Nest$monNewResultInternal
    at com.facebook.drawee.controller.AbstractDraweeController$2.onNewResultImpl(AbstractDraweeController.java:600)
    at com.facebook.datasource.BaseDataSubscriber.onNewResult(BaseDataSubscriber.java:51)
    at com.facebook.datasource.AbstractDataSource$1.run(AbstractDataSource.java:200)
    at android.os.Handler.handleCallback(Handler.java:959)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loopOnce(Looper.java:257)
    at android.os.Looper.loop(Looper.java:342)
    at android.app.ActivityThread.main(ActivityThread.java:9634)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:619)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

To mitigate the crash I moved reading image info before creating drawable from it and to be also surrounded by try-catch.

## Test Plan 

Unfortunately I can't provide a test plan since the exception is thrown most likely due to some race condition.
