### PR TITLE
Fix: Corrected loop variable in DropFramesFrameScheduler

### DIFF
--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/frame/DropFramesFrameScheduler.kt
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/frame/DropFramesFrameScheduler.kt
@@ -46,7 +46,7 @@ class DropFramesFrameScheduler(private val animationInformation: AnimationInform
   override fun getTargetRenderTimeMs(frameNumber: Int): Long {
     var targetRenderTimeMs = 0L
     for (i in 0 until frameNumber) {
-      targetRenderTimeMs += animationInformation.getFrameDurationMs(frameNumber).toLong()
+      targetRenderTimeMs += animationInformation.getFrameDurationMs(i).toLong()
     }
     return targetRenderTimeMs
   }


### PR DESCRIPTION
Fixes #2849
Thanks for submitting a PR! Please read these instructions carefully:

- [x ] Explain the **motivation** for making this change.
- [ x] Provide a **test plan** demonstrating that the code is solid.
- [ x] Match the **code formatting** of the rest of the codebase.
- [ x] Target the `main` branch

## Motivation (required)

The current implementation of getTargetRenderTimeMs in DropFramesFrameScheduler.kt contains a logic error. In the summation loop, the code incorrectly uses the parameter frameNumber to fetch frame duration instead of the loop iterator i.

The Problem: If we are calculating the target time for frame 10, the code currently adds the duration of frame 10 ten times. The Fix: The code should instead sum the durations of frames 0 through 9. This bug causes incorrect timing for animations with variable frame rates (non-uniform durations), leading to glitches when skipping or jumping to specific frames.


## Test Plan (required)

**Manual Code Review:**
- Verified the loop variable change from `frameNumber` to `i` in `getTargetRenderTimeMs()`
- Confirmed the method now correctly sums frame durations from index 0 to frameNumber-1

**Build Verification:**
```bash
./gradlew :animated-drawable:assembleDebug
```
Build completed successfully with no compilation errors.

**Logic Verification Example:**
For a GIF with variable frame durations: `[30ms, 30ms, 30ms, 270ms, 270ms]`

Before fix (INCORRECT):
- `getTargetRenderTimeMs(4)` returns `270ms × 4 = 1080ms` ❌
- Repeatedly adds duration of frame 4 instead of summing frames 0-3

After fix (CORRECT):
- `getTargetRenderTimeMs(4)` returns `30+30+30+270 = 360ms` ✅
- Correctly sums durations of frames 0, 1, 2, and 3

**Impact:**
This bug caused `jumpToFrame()` to calculate incorrect animation times, leading to:
- Wrong loop count calculations
- Premature animation termination
- Especially problematic for GIFs with non-uniform frame durations

**Existing Tests:**
The module contains existing unit tests in `/animated-drawable/src/test/`. All existing tests continue to pass with this fix.

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/main/CONTRIBUTING.md
