### PR TITLE
animated-drawable: add TickScheduler and Tickable abstractions

### DIFF
--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/TickScheduler.kt
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/TickScheduler.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.fresco.animation.drawable
+
+/**
+ * Drives one or more [Tickable]s from a single source of animation frames.
+ *
+ * Deliberately named apart from [com.facebook.fresco.animation.frame.FrameScheduler], which holds
+ * per-drawable timing state and is a different abstraction.
+ */
+interface TickScheduler {
+
+  /** Starts delivering frames to [drawable]. */
+  fun register(drawable: Tickable)
+
+  /** Stops delivering frames to [drawable]. */
+  fun unregister(drawable: Tickable)
+
+  /** Whether [drawable] is currently being delivered frames. */
+  fun isRegistered(drawable: Tickable): Boolean
+}

--- a/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/Tickable.kt
+++ b/animated-drawable/src/main/java/com/facebook/fresco/animation/drawable/Tickable.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.fresco.animation.drawable
+
+/**
+ * A target that a [TickScheduler] can drive, one animation frame at a time.
+ *
+ * Implementations decide what a tick means for them; the scheduler only forwards the frame
+ * timestamp it was given by the system.
+ */
+interface Tickable {
+
+  /**
+   * Called once per scheduled frame.
+   *
+   * @param frameTimeNanos timestamp of the frame being rendered, in nanoseconds
+   * @return true if this target should keep receiving ticks, false if it is done
+   */
+  fun doFrame(frameTimeNanos: Long): Boolean
+}


### PR DESCRIPTION
Introduce the two interfaces an animation frame source and its targets need to talk to each other:

- Tickable — something that can be driven one frame at a time
- TickScheduler — something that drives Tickables

Named apart from com.facebook.fresco.animation.frame.FrameScheduler, which is per-drawable timing state rather than a frame source, so both can be imported in the same file.

No behaviour change: nothing implements or consumes these yet.

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `main` branch

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/main/CONTRIBUTING.md
